### PR TITLE
refactor(skills): remove announce-at-start lines

### DIFF
--- a/skills/finish/SKILL.md
+++ b/skills/finish/SKILL.md
@@ -10,8 +10,6 @@ type: workflow
 
 Verify → commit → choose integration method → execute → clean up.
 
-**Announce at start:** "I'm using the hexis:finish skill to complete this work."
-
 ## $ARGUMENTS
 
 If `$ARGUMENTS` contains a branch or feature description, use it as context.

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -10,8 +10,6 @@ type: workflow
 
 Execute an implementation plan. Default: dispatch subagents per task. Inline execution only when there is a clear reason not to.
 
-**Announce at start:** "I'm using the hexis:implement skill to execute this plan."
-
 ## $ARGUMENTS
 
 If `$ARGUMENTS` is a plan file path, load that file. Otherwise use the **ask-user** capability to ask for the path (see `hexis:platform-capabilities`).

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -10,8 +10,6 @@ type: workflow
 
 Write a detailed implementation plan from a spec. Real code, exact file paths, no placeholders.
 
-**Announce at start:** "I'm using the hexis:plan skill to create the implementation plan."
-
 ## $ARGUMENTS
 
 If `$ARGUMENTS` is a file path, read that spec and start. Otherwise use the **ask-user** capability to ask for the spec path (see `hexis:platform-capabilities`).

--- a/skills/use-worktree/SKILL.md
+++ b/skills/use-worktree/SKILL.md
@@ -10,8 +10,6 @@ type: workflow
 
 Set up an isolated git worktree for feature work.
 
-**Announce at start:** "I'm using the hexis:use-worktree skill to set up an isolated workspace."
-
 **Core principle:** Systematic directory selection + safety verification = reliable isolation.
 
 ## Directory Selection


### PR DESCRIPTION
## Summary

- Remove `**Announce at start:**` lines at `plan`, `implement`, `finish`, `use-worktree` skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)