### PR TITLE
feat: standardize spec and plan document formats (#20)

### DIFF
--- a/docs/plans/2026-03-27-hw0k-workflow-enhancement-content.md
+++ b/docs/plans/2026-03-27-hw0k-workflow-enhancement-content.md
@@ -1,4 +1,5 @@
 ---
+status: DONE
 linked_spec: docs/specs/2026-03-27-hw0k-workflow-enhancement-design.md
 ---
 

--- a/docs/plans/2026-03-27-hw0k-workflow-enhancement-infra.md
+++ b/docs/plans/2026-03-27-hw0k-workflow-enhancement-infra.md
@@ -1,4 +1,5 @@
 ---
+status: DONE
 linked_spec: docs/specs/2026-03-27-hw0k-workflow-enhancement-design.md
 ---
 

--- a/docs/plans/2026-03-27-hw0k-workflow-plugin.md
+++ b/docs/plans/2026-03-27-hw0k-workflow-plugin.md
@@ -1,4 +1,5 @@
 ---
+status: DONE
 linked_spec: docs/specs/2026-03-27-hw0k-workflow-plugin-design.md
 ---
 

--- a/docs/plans/2026-03-27-skill-philosophy-rewrite.md
+++ b/docs/plans/2026-03-27-skill-philosophy-rewrite.md
@@ -1,4 +1,5 @@
 ---
+status: DONE
 linked_spec: docs/specs/2026-03-27-skill-philosophy-rewrite-design.md
 ---
 

--- a/docs/plans/2026-04-01-issues-2-3-4-plan-mode-sync-pre-commit.md
+++ b/docs/plans/2026-04-01-issues-2-3-4-plan-mode-sync-pre-commit.md
@@ -1,4 +1,5 @@
 ---
+status: DONE
 linked_spec: docs/specs/2026-04-01-plan-mode-to-executing-skills-design.md
 ---
 

--- a/docs/plans/2026-04-01-specify-artifact-enforcement.md
+++ b/docs/plans/2026-04-01-specify-artifact-enforcement.md
@@ -1,4 +1,5 @@
 ---
+status: DONE
 linked_spec: docs/specs/2026-04-01-specify-artifact-enforcement-design.md
 ---
 

--- a/docs/plans/2026-04-06-dispatch-skill.md
+++ b/docs/plans/2026-04-06-dispatch-skill.md
@@ -1,5 +1,6 @@
 ---
 linked_spec: docs/specs/2026-04-06-dispatch-skill-design.md
+issue: 10
 ---
 
 # hw0k-workflow:dispatch Implementation Plan

--- a/docs/plans/2026-04-06-dispatch-skill.md
+++ b/docs/plans/2026-04-06-dispatch-skill.md
@@ -1,6 +1,7 @@
 ---
-linked_spec: docs/specs/2026-04-06-dispatch-skill-design.md
 issue: 10
+status: DONE
+linked_spec: docs/specs/2026-04-06-dispatch-skill-design.md
 ---
 
 # hw0k-workflow:dispatch Implementation Plan

--- a/docs/plans/2026-04-06-plan-decomposition.md
+++ b/docs/plans/2026-04-06-plan-decomposition.md
@@ -1,4 +1,5 @@
 ---
+status: DONE
 linked_spec: docs/specs/2026-04-06-plan-decomposition-design.md
 ---
 
@@ -67,6 +68,7 @@ Every plan must start with this header:
 ```markdown
 ---
 linked_spec: docs/specs/YYYY-MM-DD-<topic>-design.md
+status: DONE
 ---
 
 # [Feature Name] Implementation Plan
@@ -269,6 +271,7 @@ New first two blocks:
 ```markdown
 ---
 linked_spec: docs/specs/2026-03-27-hw0k-workflow-plugin-design.md
+status: DONE
 ---
 
 # hw0k-workflow Plugin Implementation Plan

--- a/docs/plans/2026-04-08-universal-task-tool-integration.md
+++ b/docs/plans/2026-04-08-universal-task-tool-integration.md
@@ -1,5 +1,6 @@
 ---
 linked_spec: docs/specs/2026-04-08-universal-task-tool-integration-design.md
+issue: 15
 ---
 
 # Universal Task Tool Integration Implementation Plan

--- a/docs/plans/2026-04-08-universal-task-tool-integration.md
+++ b/docs/plans/2026-04-08-universal-task-tool-integration.md
@@ -1,6 +1,7 @@
 ---
-linked_spec: docs/specs/2026-04-08-universal-task-tool-integration-design.md
 issue: 15
+status: DONE
+linked_spec: docs/specs/2026-04-08-universal-task-tool-integration-design.md
 ---
 
 # Universal Task Tool Integration Implementation Plan

--- a/docs/plans/2026-04-19-hexis-rename.md
+++ b/docs/plans/2026-04-19-hexis-rename.md
@@ -1,6 +1,7 @@
 ---
-linked_spec: docs/specs/2026-04-19-hexis-rename-design.md
 issue: 25
+status: DONE
+linked_spec: docs/specs/2026-04-19-hexis-rename-design.md
 ---
 
 # Hexis Rename Implementation Plan

--- a/docs/plans/2026-04-19-hexis-rename.md
+++ b/docs/plans/2026-04-19-hexis-rename.md
@@ -1,5 +1,6 @@
 ---
 linked_spec: docs/specs/2026-04-19-hexis-rename-design.md
+issue: 25
 ---
 
 # Hexis Rename Implementation Plan

--- a/docs/plans/2026-04-19-universal-skill-support.md
+++ b/docs/plans/2026-04-19-universal-skill-support.md
@@ -1,5 +1,6 @@
 ---
 linked_spec: docs/specs/2026-04-19-universal-skill-support-design.md
+issue: 16
 ---
 
 # Universal Skill Support Implementation Plan

--- a/docs/plans/2026-04-19-universal-skill-support.md
+++ b/docs/plans/2026-04-19-universal-skill-support.md
@@ -1,6 +1,7 @@
 ---
-linked_spec: docs/specs/2026-04-19-universal-skill-support-design.md
 issue: 16
+status: DONE
+linked_spec: docs/specs/2026-04-19-universal-skill-support-design.md
 ---
 
 # Universal Skill Support Implementation Plan

--- a/docs/plans/2026-04-22-tdd-workflow-restructure.md
+++ b/docs/plans/2026-04-22-tdd-workflow-restructure.md
@@ -1,6 +1,7 @@
 ---
-linked_spec: docs/specs/2026-04-22-tdd-workflow-restructure-design.md
 issue: 27
+status: DONE
+linked_spec: docs/specs/2026-04-22-tdd-workflow-restructure-design.md
 ---
 
 # TDD Workflow Restructure Implementation Plan

--- a/docs/plans/2026-04-22-tdd-workflow-restructure.md
+++ b/docs/plans/2026-04-22-tdd-workflow-restructure.md
@@ -1,5 +1,6 @@
 ---
 linked_spec: docs/specs/2026-04-22-tdd-workflow-restructure-design.md
+issue: 27
 ---
 
 # TDD Workflow Restructure Implementation Plan

--- a/docs/plans/2026-04-23-document-formats.md
+++ b/docs/plans/2026-04-23-document-formats.md
@@ -32,7 +32,7 @@ issue: 20
 **Files:**
 - Modify: `skills/specify/SKILL.md:94-110`
 
-- [ ] **Step 1: Implement**
+- [x] **Step 1: Implement**
 
 Replace in `skills/specify/SKILL.md`:
 
@@ -64,7 +64,7 @@ issue: N
 Where `N` is the GitHub issue number this spec addresses (bare integer, no `#`). If there is no associated issue, omit the frontmatter. The `issue: N` frontmatter field is required for `hexis:dispatch` to locate the spec by issue number.
 ```
 
-- [ ] **Step 2: Verify**
+- [x] **Step 2: Verify**
 
 ```bash
 grep -A 12 "Step 4: Write and Commit" skills/specify/SKILL.md | grep "issue: N"
@@ -72,7 +72,7 @@ grep -A 12 "Step 4: Write and Commit" skills/specify/SKILL.md | grep "issue: N"
 
 Expected: `issue: N`
 
-- [ ] **Step 3: Commit** *(skip — commit at end of Task 5 with all skills together)*
+- [x] **Step 3: Commit** *(skip — commit at end of Task 5 with all skills together)*
 
 ---
 
@@ -82,7 +82,7 @@ Expected: `issue: N`
 - Modify: `skills/plan/SKILL.md:60-63` (Plan Header frontmatter)
 - Modify: `skills/plan/SKILL.md:187-189` (Save section)
 
-- [ ] **Step 1: Implement Edit A — Plan Header frontmatter**
+- [x] **Step 1: Implement Edit A — Plan Header frontmatter**
 
 Replace in `skills/plan/SKILL.md`:
 
@@ -101,7 +101,7 @@ issue: N
 ---
 ```
 
-- [ ] **Step 2: Implement Edit B — Save section**
+- [x] **Step 2: Implement Edit B — Save section**
 
 Replace in `skills/plan/SKILL.md`:
 
@@ -120,7 +120,7 @@ With:
 2. Update the linked spec's YAML frontmatter: add `plan: docs/plans/<filename>.md`. Commit: `docs: add plan back-link to <topic> spec (#N)`.
 ```
 
-- [ ] **Step 3: Verify**
+- [x] **Step 3: Verify**
 
 ```bash
 grep "issue: N" skills/plan/SKILL.md && grep "plan back-link" skills/plan/SKILL.md
@@ -137,7 +137,7 @@ Expected: both lines found
 - Modify: `skills/dispatch/SKILL.md:63-64` (spec_found/plan_found description)
 - Modify: `skills/dispatch/SKILL.md:114` (Notes)
 
-- [ ] **Step 1: Implement Edit A — grep commands**
+- [x] **Step 1: Implement Edit A — grep commands**
 
 Replace in `skills/dispatch/SKILL.md`:
 
@@ -155,7 +155,7 @@ grep -rl "^issue: N$" docs/plans/ 2>/dev/null
 
 Where `N` is the literal issue number (e.g., for issue 20: `grep -rl "^issue: 20$" docs/specs/ 2>/dev/null`).
 
-- [ ] **Step 2: Implement Edit B — Collect description**
+- [x] **Step 2: Implement Edit B — Collect description**
 
 Replace in `skills/dispatch/SKILL.md`:
 
@@ -171,7 +171,7 @@ With:
 - `plan_found`: true if any file in `docs/plans/` has frontmatter line `issue: N`
 ```
 
-- [ ] **Step 3: Implement Edit C — Notes**
+- [x] **Step 3: Implement Edit C — Notes**
 
 Replace in `skills/dispatch/SKILL.md`:
 
@@ -185,7 +185,7 @@ With:
 - If spec/plan files do not have `issue: N` in their YAML frontmatter, dispatch cannot locate them — they are treated as non-existent, and dispatch routes to `specify` or `plan` accordingly.
 ```
 
-- [ ] **Step 4: Verify**
+- [x] **Step 4: Verify**
 
 ```bash
 grep "^issue: N" skills/dispatch/SKILL.md
@@ -200,7 +200,7 @@ Expected: two lines (one for specs, one for plans)
 **Files:**
 - Modify: `skills/sync-working-status/SKILL.md:47-52`
 
-- [ ] **Step 1: Implement**
+- [x] **Step 1: Implement**
 
 Replace in `skills/sync-working-status/SKILL.md`:
 
@@ -222,7 +222,7 @@ gh issue list --state open --json number,title
 grep -rn "^issue: " docs/specs/
 ```
 
-- [ ] **Step 2: Verify**
+- [x] **Step 2: Verify**
 
 ```bash
 grep "^issue: " skills/sync-working-status/SKILL.md
@@ -237,7 +237,7 @@ Expected: `grep -rn "^issue: " docs/specs/`
 **Files:**
 - Modify: `skills/review/SKILL.md` (Red Flags section)
 
-- [ ] **Step 1: Implement**
+- [x] **Step 1: Implement**
 
 Replace in `skills/review/SKILL.md`:
 
@@ -252,7 +252,7 @@ With:
 - Spec or plan files in the diff that don't follow `docs/templates/spec.md` / `docs/templates/plan.md`
 ```
 
-- [ ] **Step 2: Verify**
+- [x] **Step 2: Verify**
 
 ```bash
 grep "docs/templates" skills/review/SKILL.md
@@ -260,7 +260,7 @@ grep "docs/templates" skills/review/SKILL.md
 
 Expected: `docs/templates/spec.md` / `docs/templates/plan.md`
 
-- [ ] **Step 3: Commit all skills changes together**
+- [x] **Step 3: Commit all skills changes together**
 
 ```bash
 git add skills/specify/SKILL.md skills/plan/SKILL.md skills/dispatch/SKILL.md skills/sync-working-status/SKILL.md skills/review/SKILL.md
@@ -274,7 +274,7 @@ git commit -m "feat(skills): update specify/plan/dispatch/sync/review to use fro
 **Files:**
 - Modify: all 17 existing files in `docs/specs/`
 
-- [ ] **Step 1: Implement**
+- [x] **Step 1: Implement**
 
 Create and run the following Python script from the repo root:
 
@@ -348,7 +348,7 @@ for fname in sorted(os.listdir(specs_dir)):
     print(f"Updated: {fname} (issue={issue_num}, plans={plans})")
 ```
 
-- [ ] **Step 2: Verify**
+- [x] **Step 2: Verify**
 
 ```bash
 grep -l "^---" docs/specs/*.md | wc -l
@@ -362,7 +362,7 @@ grep -rl "^Issue: #" docs/specs/
 
 Expected: no output (all `Issue: #N` body lines removed)
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 git add docs/specs/
@@ -378,7 +378,7 @@ git commit -m "docs(specs): backfill frontmatter — move issue number from body
 
 **Note:** Task 6 must be complete before Task 7 — the plan backfill reads issue numbers from spec frontmatter.
 
-- [ ] **Step 1: Implement**
+- [x] **Step 1: Implement**
 
 Create and run the following Python script from the repo root:
 
@@ -435,7 +435,7 @@ for fname in sorted(os.listdir(plans_dir)):
     print(f"Updated: {fname} (issue={issue_num})")
 ```
 
-- [ ] **Step 2: Verify**
+- [x] **Step 2: Verify**
 
 ```bash
 grep -l "^issue:" docs/plans/*.md | wc -l
@@ -444,7 +444,7 @@ grep -l "^issue:" docs/plans/*.md | wc -l
 Expected: `5`
 (dispatch #10, universal-task-tool #15, universal-skill-support #16, hexis-rename #25, tdd-restructure #27)
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 git add docs/plans/

--- a/docs/plans/2026-04-23-document-formats.md
+++ b/docs/plans/2026-04-23-document-formats.md
@@ -1,0 +1,452 @@
+---
+linked_spec: docs/specs/2026-04-23-document-formats-design.md
+issue: 20
+---
+
+# Document Formats Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `hexis:implement` to execute task by task. For TDD tasks, follow `hexis:testing-principles`. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Standardize spec and plan document formats by moving all machine-readable fields to YAML frontmatter and updating every skill and file that produces or consumes them.
+
+**Architecture:** Pure markdown edits across two layers — (1) skill definitions in `skills/` that govern future output, (2) backfill of all existing files in `docs/specs/` and `docs/plans/`. Two commit groups: skills first, backfill second.
+
+**Tech Stack:** Markdown, YAML frontmatter, Python 3 (backfill scripts), bash
+
+---
+
+## File Structure
+
+- Modify: `skills/specify/SKILL.md` — Step 4 output format
+- Modify: `skills/plan/SKILL.md` — Plan Header frontmatter + Save section
+- Modify: `skills/dispatch/SKILL.md` — grep commands + Notes
+- Modify: `skills/sync-working-status/SKILL.md` — 1 Spec = 1 Issue bash block
+- Modify: `skills/review/SKILL.md` — Red Flags section
+- Modify: all 17 files in `docs/specs/` — add frontmatter, remove `Issue: #N` body line
+- Modify: all 12 files in `docs/plans/` — add `issue: N` to frontmatter where applicable
+
+---
+
+### Task 1: Update skills/specify/SKILL.md [No TDD — modifying skill documentation]
+
+**Files:**
+- Modify: `skills/specify/SKILL.md:94-110`
+
+- [ ] **Step 1: Implement**
+
+Replace in `skills/specify/SKILL.md`:
+
+```
+Write to `docs/specs/YYYY-MM-DD-<topic>-design.md`. The file must begin with:
+
+```markdown
+# <Title>
+
+Issue: #N
+```
+
+Where `N` is the GitHub issue number this spec addresses. If there is no associated issue, omit the `Issue:` line. This line is required for `hexis:dispatch` to locate the spec by issue number.
+```
+
+With:
+
+```
+Write to `docs/specs/YYYY-MM-DD-<topic>-design.md`. The file must match `docs/templates/spec.md`. The file must begin with:
+
+```markdown
+---
+issue: N
+---
+
+# <Title>
+```
+
+Where `N` is the GitHub issue number this spec addresses (bare integer, no `#`). If there is no associated issue, omit the frontmatter. The `issue: N` frontmatter field is required for `hexis:dispatch` to locate the spec by issue number.
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+grep -A 12 "Step 4: Write and Commit" skills/specify/SKILL.md | grep "issue: N"
+```
+
+Expected: `issue: N`
+
+- [ ] **Step 3: Commit** *(skip — commit at end of Task 5 with all skills together)*
+
+---
+
+### Task 2: Update skills/plan/SKILL.md [No TDD — modifying skill documentation]
+
+**Files:**
+- Modify: `skills/plan/SKILL.md:60-63` (Plan Header frontmatter)
+- Modify: `skills/plan/SKILL.md:187-189` (Save section)
+
+- [ ] **Step 1: Implement Edit A — Plan Header frontmatter**
+
+Replace in `skills/plan/SKILL.md`:
+
+```
+---
+linked_spec: docs/specs/YYYY-MM-DD-<topic>-design.md
+---
+```
+
+With:
+
+```
+---
+linked_spec: docs/specs/YYYY-MM-DD-<topic>-design.md
+issue: N
+---
+```
+
+- [ ] **Step 2: Implement Edit B — Save section**
+
+Replace in `skills/plan/SKILL.md`:
+
+```
+## Save
+
+`docs/plans/YYYY-MM-DD-<feature>.md`. Commit: `docs: add <feature> plan`.
+```
+
+With:
+
+```
+## Save
+
+1. Write `docs/plans/YYYY-MM-DD-<feature>.md`. Commit: `docs: add <feature> plan`.
+2. Update the linked spec's YAML frontmatter: add `plan: docs/plans/<filename>.md`. Commit: `docs: add plan back-link to <topic> spec (#N)`.
+```
+
+- [ ] **Step 3: Verify**
+
+```bash
+grep "issue: N" skills/plan/SKILL.md && grep "plan back-link" skills/plan/SKILL.md
+```
+
+Expected: both lines found
+
+---
+
+### Task 3: Update skills/dispatch/SKILL.md [No TDD — modifying skill documentation]
+
+**Files:**
+- Modify: `skills/dispatch/SKILL.md:56-58` (grep commands)
+- Modify: `skills/dispatch/SKILL.md:63-64` (spec_found/plan_found description)
+- Modify: `skills/dispatch/SKILL.md:114` (Notes)
+
+- [ ] **Step 1: Implement Edit A — grep commands**
+
+Replace in `skills/dispatch/SKILL.md`:
+
+```bash
+grep -rl "#N" docs/specs/ 2>/dev/null
+grep -rl "#N" docs/plans/ 2>/dev/null
+```
+
+With:
+
+```bash
+grep -rl "^issue: N$" docs/specs/ 2>/dev/null
+grep -rl "^issue: N$" docs/plans/ 2>/dev/null
+```
+
+Where `N` is the literal issue number (e.g., for issue 20: `grep -rl "^issue: 20$" docs/specs/ 2>/dev/null`).
+
+- [ ] **Step 2: Implement Edit B — Collect description**
+
+Replace in `skills/dispatch/SKILL.md`:
+
+```
+- `spec_found`: true if any file in `docs/specs/` contains `#N`
+- `plan_found`: true if any file in `docs/plans/` contains `#N`
+```
+
+With:
+
+```
+- `spec_found`: true if any file in `docs/specs/` has frontmatter line `issue: N`
+- `plan_found`: true if any file in `docs/plans/` has frontmatter line `issue: N`
+```
+
+- [ ] **Step 3: Implement Edit C — Notes**
+
+Replace in `skills/dispatch/SKILL.md`:
+
+```
+- If spec/plan files do not embed `Issue: #N` in their content, dispatch cannot locate them — they are treated as non-existent, and dispatch routes to `specify` or `plan` accordingly.
+```
+
+With:
+
+```
+- If spec/plan files do not have `issue: N` in their YAML frontmatter, dispatch cannot locate them — they are treated as non-existent, and dispatch routes to `specify` or `plan` accordingly.
+```
+
+- [ ] **Step 4: Verify**
+
+```bash
+grep "^issue: N" skills/dispatch/SKILL.md
+```
+
+Expected: two lines (one for specs, one for plans)
+
+---
+
+### Task 4: Update skills/sync-working-status/SKILL.md [No TDD — modifying skill documentation]
+
+**Files:**
+- Modify: `skills/sync-working-status/SKILL.md:47-52`
+
+- [ ] **Step 1: Implement**
+
+Replace in `skills/sync-working-status/SKILL.md`:
+
+```bash
+# List open issues
+gh issue list --state open --json number,title
+
+# List spec files
+ls docs/specs/
+```
+
+With:
+
+```bash
+# List open issues
+gh issue list --state open --json number,title
+
+# List spec files with their issue numbers
+grep -rn "^issue: " docs/specs/
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+grep "^issue: " skills/sync-working-status/SKILL.md
+```
+
+Expected: `grep -rn "^issue: " docs/specs/`
+
+---
+
+### Task 5: Update skills/review/SKILL.md [No TDD — modifying skill documentation]
+
+**Files:**
+- Modify: `skills/review/SKILL.md` (Red Flags section)
+
+- [ ] **Step 1: Implement**
+
+Replace in `skills/review/SKILL.md`:
+
+```
+- Skip review because "it's simple"
+```
+
+With:
+
+```
+- Skip review because "it's simple"
+- Spec or plan files in the diff that don't follow `docs/templates/spec.md` / `docs/templates/plan.md`
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+grep "docs/templates" skills/review/SKILL.md
+```
+
+Expected: `docs/templates/spec.md` / `docs/templates/plan.md`
+
+- [ ] **Step 3: Commit all skills changes together**
+
+```bash
+git add skills/specify/SKILL.md skills/plan/SKILL.md skills/dispatch/SKILL.md skills/sync-working-status/SKILL.md skills/review/SKILL.md
+git commit -m "feat(skills): update specify/plan/dispatch/sync/review to use frontmatter issue field (#20)"
+```
+
+---
+
+### Task 6: Backfill docs/specs/ [No TDD — bulk markdown backfill]
+
+**Files:**
+- Modify: all 17 existing files in `docs/specs/`
+
+- [ ] **Step 1: Implement**
+
+Create and run the following Python script from the repo root:
+
+```python
+#!/usr/bin/env python3
+import os, re
+
+SPEC_TO_PLANS = {
+    "2026-04-06-dispatch-skill-design": ["2026-04-06-dispatch-skill.md"],
+    "2026-04-08-universal-task-tool-integration-design": ["2026-04-08-universal-task-tool-integration.md"],
+    "2026-04-19-universal-skill-support-design": ["2026-04-19-universal-skill-support.md"],
+    "2026-04-19-hexis-rename-design": ["2026-04-19-hexis-rename.md"],
+    "2026-04-22-tdd-workflow-restructure-design": ["2026-04-22-tdd-workflow-restructure.md"],
+    "2026-03-27-hw0k-workflow-enhancement-design": [
+        "2026-03-27-hw0k-workflow-enhancement-content.md",
+        "2026-03-27-hw0k-workflow-enhancement-infra.md",
+    ],
+    "2026-03-27-hw0k-workflow-plugin-design": ["2026-03-27-hw0k-workflow-plugin.md"],
+    "2026-03-27-skill-philosophy-rewrite-design": ["2026-03-27-skill-philosophy-rewrite.md"],
+    "2026-04-01-plan-mode-to-executing-skills-design": ["2026-04-01-issues-2-3-4-plan-mode-sync-pre-commit.md"],
+    "2026-04-01-specify-artifact-enforcement-design": ["2026-04-01-specify-artifact-enforcement.md"],
+    "2026-04-06-plan-decomposition-design": ["2026-04-06-plan-decomposition.md"],
+}
+
+SKIP = {"2026-04-23-document-formats-design"}
+
+specs_dir = "docs/specs"
+
+for fname in sorted(os.listdir(specs_dir)):
+    if not fname.endswith(".md"):
+        continue
+    stem = fname[:-3]
+    if stem in SKIP:
+        print(f"SKIP (already correct): {fname}")
+        continue
+
+    path = os.path.join(specs_dir, fname)
+    with open(path) as f:
+        content = f.read()
+
+    if content.startswith("---\n"):
+        print(f"SKIP (already has frontmatter): {fname}")
+        continue
+
+    issue_match = re.search(r"^Issue: #(\d+)\s*$", content, re.MULTILINE)
+    issue_num = int(issue_match.group(1)) if issue_match else None
+
+    plans = SPEC_TO_PLANS.get(stem, [])
+
+    fm_lines = ["---"]
+    if issue_num:
+        fm_lines.append(f"issue: {issue_num}")
+    if len(plans) == 1:
+        fm_lines.append(f"plan: docs/plans/{plans[0]}")
+    elif len(plans) > 1:
+        fm_lines.append("plan:")
+        for p in plans:
+            fm_lines.append(f"  - docs/plans/{p}")
+    fm_lines.append("---")
+
+    if len(fm_lines) == 2:  # only --- delimiters, nothing inside
+        print(f"SKIP (no issue, no plan): {fname}")
+        continue
+
+    frontmatter = "\n".join(fm_lines) + "\n\n"
+    new_body = re.sub(r"^Issue: #\d+\n\n?", "", content, flags=re.MULTILINE)
+    new_content = frontmatter + new_body
+
+    with open(path, "w") as f:
+        f.write(new_content)
+    print(f"Updated: {fname} (issue={issue_num}, plans={plans})")
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+grep -l "^---" docs/specs/*.md | wc -l
+```
+
+Expected: `15` (8 specs with issue + 6 specs with plan-only frontmatter + 1 already-correct new spec)
+
+```bash
+grep -rl "^Issue: #" docs/specs/
+```
+
+Expected: no output (all `Issue: #N` body lines removed)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/specs/
+git commit -m "docs(specs): backfill frontmatter — move issue number from body to YAML (#20)"
+```
+
+---
+
+### Task 7: Backfill docs/plans/ [No TDD — bulk markdown backfill]
+
+**Files:**
+- Modify: up to 12 files in `docs/plans/` (those whose linked spec has an issue number)
+
+**Note:** Task 6 must be complete before Task 7 — the plan backfill reads issue numbers from spec frontmatter.
+
+- [ ] **Step 1: Implement**
+
+Create and run the following Python script from the repo root:
+
+```python
+#!/usr/bin/env python3
+import os, re
+
+plans_dir = "docs/plans"
+
+for fname in sorted(os.listdir(plans_dir)):
+    if not fname.endswith(".md"):
+        continue
+
+    path = os.path.join(plans_dir, fname)
+    with open(path) as f:
+        content = f.read()
+
+    if not content.startswith("---\n"):
+        print(f"SKIP (no frontmatter): {fname}")
+        continue
+
+    if re.search(r"^issue: \d+", content, re.MULTILINE):
+        print(f"SKIP (already has issue): {fname}")
+        continue
+
+    spec_match = re.search(r"^linked_spec: (.+)$", content, re.MULTILINE)
+    if not spec_match:
+        print(f"SKIP (no linked_spec): {fname}")
+        continue
+
+    spec_path = spec_match.group(1).strip()
+    if not os.path.exists(spec_path):
+        print(f"SKIP (spec not found: {spec_path}): {fname}")
+        continue
+
+    with open(spec_path) as f:
+        spec_content = f.read()
+
+    issue_match = re.search(r"^issue: (\d+)$", spec_content, re.MULTILINE)
+    if not issue_match:
+        print(f"SKIP (spec has no issue number): {fname}")
+        continue
+
+    issue_num = issue_match.group(1)
+    new_content = re.sub(
+        r"(^linked_spec: .+$)",
+        rf"\1\nissue: {issue_num}",
+        content,
+        flags=re.MULTILINE,
+    )
+
+    with open(path, "w") as f:
+        f.write(new_content)
+    print(f"Updated: {fname} (issue={issue_num})")
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+grep -l "^issue:" docs/plans/*.md | wc -l
+```
+
+Expected: `5`
+(dispatch #10, universal-task-tool #15, universal-skill-support #16, hexis-rename #25, tdd-restructure #27)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/plans/
+git commit -m "docs(plans): backfill issue frontmatter field from linked spec (#20)"
+```

--- a/docs/plans/2026-04-23-document-formats.md
+++ b/docs/plans/2026-04-23-document-formats.md
@@ -1,6 +1,7 @@
 ---
-linked_spec: docs/specs/2026-04-23-document-formats-design.md
 issue: 20
+status: IN_PROGRESS
+linked_spec: docs/specs/2026-04-23-document-formats-design.md
 ---
 
 # Document Formats Implementation Plan

--- a/docs/specs/2026-03-27-hw0k-workflow-enhancement-design.md
+++ b/docs/specs/2026-03-27-hw0k-workflow-enhancement-design.md
@@ -1,7 +1,4 @@
 ---
-plan:
-  - docs/plans/2026-03-27-hw0k-workflow-enhancement-content.md
-  - docs/plans/2026-03-27-hw0k-workflow-enhancement-infra.md
 ---
 
 # hw0k-workflow Enhancement Design

--- a/docs/specs/2026-03-27-hw0k-workflow-enhancement-design.md
+++ b/docs/specs/2026-03-27-hw0k-workflow-enhancement-design.md
@@ -1,3 +1,9 @@
+---
+plan:
+  - docs/plans/2026-03-27-hw0k-workflow-enhancement-content.md
+  - docs/plans/2026-03-27-hw0k-workflow-enhancement-infra.md
+---
+
 # hw0k-workflow Enhancement Design
 
 > **Historical document.** This spec reflects the initial design state. Some skill names have since been renamed (e.g., `conventional-commit` → `commit-principles`, `new-project-setup` → `setup-new-project`).

--- a/docs/specs/2026-03-27-hw0k-workflow-enhancement-design.md
+++ b/docs/specs/2026-03-27-hw0k-workflow-enhancement-design.md
@@ -1,4 +1,5 @@
 ---
+status: DONE
 ---
 
 # hw0k-workflow Enhancement Design

--- a/docs/specs/2026-03-27-hw0k-workflow-plugin-design.md
+++ b/docs/specs/2026-03-27-hw0k-workflow-plugin-design.md
@@ -1,5 +1,4 @@
 ---
-plan: docs/plans/2026-03-27-hw0k-workflow-plugin.md
 ---
 
 # hw0k-workflow Plugin Design

--- a/docs/specs/2026-03-27-hw0k-workflow-plugin-design.md
+++ b/docs/specs/2026-03-27-hw0k-workflow-plugin-design.md
@@ -1,3 +1,7 @@
+---
+plan: docs/plans/2026-03-27-hw0k-workflow-plugin.md
+---
+
 # hw0k-workflow Plugin Design
 
 > **Historical document.** This spec reflects the initial design state. Some skill names have since been renamed (e.g., `conventional-commit` → `commit-principles`, `new-project-setup` → `setup-new-project`).

--- a/docs/specs/2026-03-27-hw0k-workflow-plugin-design.md
+++ b/docs/specs/2026-03-27-hw0k-workflow-plugin-design.md
@@ -1,4 +1,5 @@
 ---
+status: DONE
 ---
 
 # hw0k-workflow Plugin Design

--- a/docs/specs/2026-03-27-skill-philosophy-rewrite-design.md
+++ b/docs/specs/2026-03-27-skill-philosophy-rewrite-design.md
@@ -1,5 +1,4 @@
 ---
-plan: docs/plans/2026-03-27-skill-philosophy-rewrite.md
 ---
 
 # Skill Philosophy Rewrite Design

--- a/docs/specs/2026-03-27-skill-philosophy-rewrite-design.md
+++ b/docs/specs/2026-03-27-skill-philosophy-rewrite-design.md
@@ -1,4 +1,5 @@
 ---
+status: DONE
 ---
 
 # Skill Philosophy Rewrite Design

--- a/docs/specs/2026-03-27-skill-philosophy-rewrite-design.md
+++ b/docs/specs/2026-03-27-skill-philosophy-rewrite-design.md
@@ -1,3 +1,7 @@
+---
+plan: docs/plans/2026-03-27-skill-philosophy-rewrite.md
+---
+
 # Skill Philosophy Rewrite Design
 
 > **Historical document.** This spec reflects the design state at the time of writing. `new-project-setup` has since been renamed to `setup-new-project`.

--- a/docs/specs/2026-03-27-testing-environment-design.md
+++ b/docs/specs/2026-03-27-testing-environment-design.md
@@ -1,4 +1,5 @@
 ---
+status: DONE
 ---
 
 # Testing Environment Design

--- a/docs/specs/2026-03-27-testing-environment-design.md
+++ b/docs/specs/2026-03-27-testing-environment-design.md
@@ -1,3 +1,6 @@
+---
+---
+
 # Testing Environment Design
 
 > **Historical document.** This spec compares testing approaches from a prior tooling setup with hw0k-workflow. References to the previous tooling are preserved as research context.

--- a/docs/specs/2026-04-01-migrate-lefthook-to-pre-commit-design.md
+++ b/docs/specs/2026-04-01-migrate-lefthook-to-pre-commit-design.md
@@ -1,3 +1,6 @@
+---
+---
+
 # Migrate lefthook to Python pre-commit (uvx)
 
 ## Problem

--- a/docs/specs/2026-04-01-migrate-lefthook-to-pre-commit-design.md
+++ b/docs/specs/2026-04-01-migrate-lefthook-to-pre-commit-design.md
@@ -1,4 +1,20 @@
 ---
+status: DONE
+checks:
+  - item: "`.pre-commit-config.yaml` exists; `lefthook.yml` deleted"
+    done: false
+  - item: "`uvx pre-commit install` + `--hook-type commit-msg` installs hooks successfully"
+    done: false
+  - item: "commit-msg hook: commitlint rejects invalid commits"
+    done: false
+  - item: "pre-commit hook: `run-if-exists.sh` runs lint/format/test"
+    done: false
+  - item: "`setup-new-project` skill updated"
+    done: false
+  - item: "`use-worktree` skill updated"
+    done: false
+  - item: "`CLAUDE.md` lefthook references removed"
+    done: false
 ---
 
 # Migrate lefthook to Python pre-commit (uvx)
@@ -78,13 +94,3 @@ pre-commit installs directly to `.git/hooks/` (version-controlled config lives i
 
 - No changes to `run-if-exists.sh` internals
 - No changes to commitlint configuration (`.commitlintrc.yml`)
-
-## Done When
-
-- [ ] `.pre-commit-config.yaml` exists; `lefthook.yml` deleted
-- [ ] `uvx pre-commit install` + `--hook-type commit-msg` installs hooks successfully
-- [ ] commit-msg hook: commitlint rejects invalid commits
-- [ ] pre-commit hook: `run-if-exists.sh` runs lint/format/test
-- [ ] `setup-new-project` skill updated
-- [ ] `use-worktree` skill updated
-- [ ] `CLAUDE.md` lefthook references removed

--- a/docs/specs/2026-04-01-plan-mode-to-executing-skills-design.md
+++ b/docs/specs/2026-04-01-plan-mode-to-executing-skills-design.md
@@ -1,4 +1,10 @@
 ---
+status: DONE
+checks:
+  - item: "`specify` and `plan` skills have no EnterPlanMode/ExitPlanMode references"
+    done: false
+  - item: "`write-test`, `implement`, `verify` skills enter plan mode based on complexity criteria"
+    done: false
 ---
 
 # Plan Mode Migration to Executing Task Skills
@@ -39,8 +45,3 @@ Simple task  → skip plan mode (proceed directly)
 
 - No other logic changes to specify or plan skills
 - No changes to human gate mechanisms other than plan mode
-
-## Done When
-
-- [ ] `specify` and `plan` skills have no EnterPlanMode/ExitPlanMode references
-- [ ] `write-test`, `implement`, `verify` skills enter plan mode based on complexity criteria

--- a/docs/specs/2026-04-01-plan-mode-to-executing-skills-design.md
+++ b/docs/specs/2026-04-01-plan-mode-to-executing-skills-design.md
@@ -1,5 +1,4 @@
 ---
-plan: docs/plans/2026-04-01-issues-2-3-4-plan-mode-sync-pre-commit.md
 ---
 
 # Plan Mode Migration to Executing Task Skills

--- a/docs/specs/2026-04-01-plan-mode-to-executing-skills-design.md
+++ b/docs/specs/2026-04-01-plan-mode-to-executing-skills-design.md
@@ -1,3 +1,7 @@
+---
+plan: docs/plans/2026-04-01-issues-2-3-4-plan-mode-sync-pre-commit.md
+---
+
 # Plan Mode Migration to Executing Task Skills
 
 ## Problem

--- a/docs/specs/2026-04-01-specify-artifact-enforcement-design.md
+++ b/docs/specs/2026-04-01-specify-artifact-enforcement-design.md
@@ -1,4 +1,5 @@
 ---
+status: DONE
 ---
 
 # Specify Skill — Artifact Enforcement Design
@@ -61,11 +62,3 @@ New rule in the Rules section:
 - New files or new tools
 - Changes to ExitPlanMode tool behavior
 - Verification gates inside the plan skill itself
-
-## Done When
-
-1. `specify/SKILL.md` has an explicit HARD-GATE at Step 5
-2. Plan file draft is clearly labeled as NOT the output artifact in Step 3
-3. Step 4 is labeled MANDATORY with "immediately, before anything else" language
-4. ExitPlanMode-rejected recovery path is in the Rules section
-5. User-skip confirmation gate is in the Rules section

--- a/docs/specs/2026-04-01-specify-artifact-enforcement-design.md
+++ b/docs/specs/2026-04-01-specify-artifact-enforcement-design.md
@@ -1,3 +1,7 @@
+---
+plan: docs/plans/2026-04-01-specify-artifact-enforcement.md
+---
+
 # Specify Skill — Artifact Enforcement Design
 
 **Date:** 2026-04-01

--- a/docs/specs/2026-04-01-specify-artifact-enforcement-design.md
+++ b/docs/specs/2026-04-01-specify-artifact-enforcement-design.md
@@ -1,5 +1,4 @@
 ---
-plan: docs/plans/2026-04-01-specify-artifact-enforcement.md
 ---
 
 # Specify Skill — Artifact Enforcement Design

--- a/docs/specs/2026-04-01-sync-working-status-in-executing-skills-design.md
+++ b/docs/specs/2026-04-01-sync-working-status-in-executing-skills-design.md
@@ -1,4 +1,8 @@
 ---
+status: DONE
+checks:
+  - item: "All three skills (`write-test`, `implement`, `verify`) include a `sync-working-status` invocation at their completion stage"
+    done: false
 ---
 
 # Sync Working Status in Executing Task Skills
@@ -32,7 +36,3 @@ Executing skills produce real work (code, commits). Syncing state at the point o
 
 - No changes to the `sync-working-status` skill itself
 - No additions to `specify`, `plan`, `debug`, or other non-executing skills
-
-## Done When
-
-- [ ] All three skills (`write-test`, `implement`, `verify`) include a `sync-working-status` invocation at their completion stage

--- a/docs/specs/2026-04-01-sync-working-status-in-executing-skills-design.md
+++ b/docs/specs/2026-04-01-sync-working-status-in-executing-skills-design.md
@@ -1,3 +1,6 @@
+---
+---
+
 # Sync Working Status in Executing Task Skills
 
 ## Problem

--- a/docs/specs/2026-04-06-dispatch-skill-design.md
+++ b/docs/specs/2026-04-06-dispatch-skill-design.md
@@ -1,6 +1,9 @@
-# hw0k-workflow:dispatch Skill Design
+---
+issue: 10
+plan: docs/plans/2026-04-06-dispatch-skill.md
+---
 
-Issue: #10
+# hw0k-workflow:dispatch Skill Design
 
 ## Problem
 

--- a/docs/specs/2026-04-06-dispatch-skill-design.md
+++ b/docs/specs/2026-04-06-dispatch-skill-design.md
@@ -1,6 +1,5 @@
 ---
 issue: 10
-plan: docs/plans/2026-04-06-dispatch-skill.md
 ---
 
 # hw0k-workflow:dispatch Skill Design

--- a/docs/specs/2026-04-06-dispatch-skill-design.md
+++ b/docs/specs/2026-04-06-dispatch-skill-design.md
@@ -1,5 +1,23 @@
 ---
 issue: 10
+status: DONE
+checks:
+  - item: "`skills/dispatch/SKILL.md` exists with correct frontmatter"
+    done: false
+  - item: "Skill detects state from git branch, git status, docs/specs/, docs/plans/, and GitHub PR"
+    done: false
+  - item: "Routes to the correct next skill based on routing table (first-match)"
+    done: false
+  - item: "Directly invokes the next skill — not just recommends"
+    done: false
+  - item: "Works correctly when invoked at any point in the workflow"
+    done: false
+  - item: "Outputs workflow enforcement header on every run"
+    done: false
+  - item: "`sync-working-status` path instructs re-run instead of auto-resuming"
+    done: false
+  - item: "\"No issue detected\" path asks user before defaulting to `specify`"
+    done: false
 ---
 
 # hw0k-workflow:dispatch Skill Design
@@ -102,14 +120,3 @@ This serves as the explicit acknowledgment that hw0k-workflow rules are in effec
 ## Issue Number in Spec/Plan Files
 
 For dispatch to find spec/plan files by issue number, those files must reference the issue number. Convention: include `Issue: #N` in the file header (as this spec does). The `specify` skill should embed this when creating new spec files.
-
-## Done When
-
-- [ ] `skills/dispatch/SKILL.md` exists with correct frontmatter
-- [ ] Skill detects state from git branch, git status, docs/specs/, docs/plans/, and GitHub PR
-- [ ] Routes to the correct next skill based on routing table (first-match)
-- [ ] Directly invokes the next skill — not just recommends
-- [ ] Works correctly when invoked at any point in the workflow
-- [ ] Outputs workflow enforcement header on every run
-- [ ] `sync-working-status` path instructs re-run instead of auto-resuming
-- [ ] "No issue detected" path asks user before defaulting to `specify`

--- a/docs/specs/2026-04-06-plan-decomposition-design.md
+++ b/docs/specs/2026-04-06-plan-decomposition-design.md
@@ -1,6 +1,17 @@
 ---
-title: Plan Decomposition and Spec–Issue Alignment
 issue: 6
+status: DONE
+checks:
+  - item: "All Plan files include `linked_spec` frontmatter"
+    done: true
+  - item: "`specify` can split into N Specs + N Issues when scope is too large or multi-topic"
+    done: true
+  - item: "`plan` can split into N Specs + N Plans + N Issues when independent parallelism is detected"
+    done: true
+  - item: "Single-unit path unchanged except for `linked_spec` addition"
+    done: true
+  - item: "`sync-working-status` surfaces Spec–Issue mismatches"
+    done: true
 ---
 
 # Plan Decomposition and Spec–Issue Alignment
@@ -82,11 +93,3 @@ Issues are standalone — no sub-issue relationship to the original.
 
 - Decomposition does not cascade: Plan files are never further decomposed.
 - `sync-working-status` changes are limited to surfacing discrepancies, not auto-resolving them.
-
-## Done When
-
-- All Plan files include `linked_spec` frontmatter
-- `specify` can split into N Specs + N Issues when scope is too large or multi-topic
-- `plan` can split into N Specs + N Plans + N Issues when independent parallelism is detected
-- Single-unit path unchanged except for `linked_spec` addition
-- `sync-working-status` surfaces Spec–Issue mismatches

--- a/docs/specs/2026-04-06-plan-decomposition-design.md
+++ b/docs/specs/2026-04-06-plan-decomposition-design.md
@@ -1,6 +1,6 @@
 ---
 title: Plan Decomposition and Spec–Issue Alignment
-issue: "#6"
+issue: 6
 ---
 
 # Plan Decomposition and Spec–Issue Alignment

--- a/docs/specs/2026-04-08-cli-enforced-integration-gate-design.md
+++ b/docs/specs/2026-04-08-cli-enforced-integration-gate-design.md
@@ -1,6 +1,8 @@
-# CLI-Enforced Integration Gate
+---
+issue: 21
+---
 
-Issue: #21
+# CLI-Enforced Integration Gate
 
 > **Superseded.** Decomposed into: [hw0k CLI Tool](2026-04-08-hw0k-cli-tool-design.md) (#22), [Skill Integration Gate](2026-04-08-skill-integration-gate-design.md) (#23)
 

--- a/docs/specs/2026-04-08-cli-enforced-integration-gate-design.md
+++ b/docs/specs/2026-04-08-cli-enforced-integration-gate-design.md
@@ -1,5 +1,6 @@
 ---
 issue: 21
+status: DONE
 ---
 
 # CLI-Enforced Integration Gate
@@ -57,7 +58,3 @@ Each skill adds a `## CLI Integration Gate` section. The LLM runs `hw0k status r
 - GitHub API calls from the CLI
 - LLM interpretation of workflow state
 - Persistent state files
-
-## Done When
-
-> See decomposed specs: [#22](2026-04-08-hw0k-cli-tool-design.md), [#23](2026-04-08-skill-integration-gate-design.md)

--- a/docs/specs/2026-04-08-hexis-cli-tool-design.md
+++ b/docs/specs/2026-04-08-hexis-cli-tool-design.md
@@ -1,6 +1,8 @@
-# hexis CLI Tool
+---
+issue: 22
+---
 
-Issue: #22
+# hexis CLI Tool
 
 Decomposed from: #21
 

--- a/docs/specs/2026-04-08-hexis-cli-tool-design.md
+++ b/docs/specs/2026-04-08-hexis-cli-tool-design.md
@@ -1,5 +1,21 @@
 ---
 issue: 22
+status: READY_TO_PLAN
+checks:
+  - item: "`hexis status read <issue>` outputs correct STATE label for all 5 states"
+    done: false
+  - item: "`hexis status read <issue> --json` outputs valid JSON with correct `state` key and `done_when` array with indices"
+    done: false
+  - item: "`hexis status update <issue> --checked <indices> --unchecked <indices>` rewrites all Done When items atomically"
+    done: false
+  - item: "Incomplete or overlapping index coverage exits 1 with an error message"
+    done: false
+  - item: "All state transitions are covered by pytest unit tests"
+    done: false
+  - item: "`uv tool install ./cli` succeeds in a clean environment"
+    done: false
+  - item: "CLI handles missing `docs/` directory gracefully (outputs `NEEDS_SPEC`, exit 0)"
+    done: false
 ---
 
 # hexis CLI Tool
@@ -150,13 +166,3 @@ Lives in the `cli/` subdirectory of the hexis repository.
 - Network calls of any kind
 - Persistent state of any kind (no marker files, no database)
 - Modifying plan task checklist items (plan tasks are read-only from the CLI)
-
-## Done When
-
-- [ ] `hexis status read <issue>` outputs correct STATE label for all 5 states
-- [ ] `hexis status read <issue> --json` outputs valid JSON with correct `state` key and `done_when` array with indices
-- [ ] `hexis status update <issue> --checked <indices> --unchecked <indices>` rewrites all Done When items atomically
-- [ ] Incomplete or overlapping index coverage exits 1 with an error message
-- [ ] All state transitions are covered by pytest unit tests
-- [ ] `uv tool install ./cli` succeeds in a clean environment
-- [ ] CLI handles missing `docs/` directory gracefully (outputs `NEEDS_SPEC`, exit 0)

--- a/docs/specs/2026-04-08-skill-integration-gate-design.md
+++ b/docs/specs/2026-04-08-skill-integration-gate-design.md
@@ -1,6 +1,8 @@
-# Skill Integration Gate
+---
+issue: 23
+---
 
-Issue: #23
+# Skill Integration Gate
 
 Decomposed from: #21
 

--- a/docs/specs/2026-04-08-skill-integration-gate-design.md
+++ b/docs/specs/2026-04-08-skill-integration-gate-design.md
@@ -1,5 +1,21 @@
 ---
 issue: 23
+status: READY_TO_PLAN
+checks:
+  - item: "`dispatch` routes via `hexis status read` output for all 5 state labels"
+    done: false
+  - item: "`specify` gate runs `hexis status read` and blocks overwrite of existing spec without confirmation"
+    done: false
+  - item: "`plan` gate runs `hexis status read` and blocks on non-`NEEDS_PLAN` state"
+    done: false
+  - item: "`write-test` and `implement` gates run `hexis status read` and block on non-`IN_PROGRESS` state"
+    done: false
+  - item: "`verify` entry gate runs `hexis status read` and blocks on non-`NEEDS_VERIFY` state"
+    done: false
+  - item: "`verify` exit gate runs `hexis status update` with complete AC state after verification"
+    done: false
+  - item: "`finish` gate runs `hexis status read` at entry and blocks on non-`DONE` state"
+    done: false
 ---
 
 # Skill Integration Gate
@@ -119,13 +135,3 @@ Rules 1 (uncommitted changes) and 5–8 (PR state) remain unchanged — they sti
 - Modifying skill process logic beyond the gate sections
 - Updating `sync-working-status`, `debug`, `review`, `receive-review` (no file-based state gates needed)
 - Adding tests for skill files (they are instructions, not code)
-
-## Done When
-
-- [ ] `dispatch` routes via `hexis status read` output for all 5 state labels
-- [ ] `specify` gate runs `hexis status read` and blocks overwrite of existing spec without confirmation
-- [ ] `plan` gate runs `hexis status read` and blocks on non-`NEEDS_PLAN` state
-- [ ] `write-test` and `implement` gates run `hexis status read` and block on non-`IN_PROGRESS` state
-- [ ] `verify` entry gate runs `hexis status read` and blocks on non-`NEEDS_VERIFY` state
-- [ ] `verify` exit gate runs `hexis status update` with complete AC state after verification
-- [ ] `finish` gate runs `hexis status read` at entry and blocks on non-`DONE` state

--- a/docs/specs/2026-04-08-universal-task-tool-integration-design.md
+++ b/docs/specs/2026-04-08-universal-task-tool-integration-design.md
@@ -1,6 +1,9 @@
-# Universal Task Tool Integration
+---
+issue: 15
+plan: docs/plans/2026-04-08-universal-task-tool-integration.md
+---
 
-Issue: #15
+# Universal Task Tool Integration
 
 ## Problem
 

--- a/docs/specs/2026-04-08-universal-task-tool-integration-design.md
+++ b/docs/specs/2026-04-08-universal-task-tool-integration-design.md
@@ -1,6 +1,5 @@
 ---
 issue: 15
-plan: docs/plans/2026-04-08-universal-task-tool-integration.md
 ---
 
 # Universal Task Tool Integration

--- a/docs/specs/2026-04-08-universal-task-tool-integration-design.md
+++ b/docs/specs/2026-04-08-universal-task-tool-integration-design.md
@@ -1,5 +1,19 @@
 ---
 issue: 15
+status: DONE
+checks:
+  - item: "All listed skills create Tasks at the step level on invocation"
+    done: false
+  - item: "Every listed skill checks `TaskList` at start and presents resume/fresh-start choice when open Tasks exist"
+    done: false
+  - item: "`TaskStop` is called on all failure and cancellation paths"
+    done: false
+  - item: "`implement` creates a parent Task and instructs each dispatched subagent to create a child Task"
+    done: false
+  - item: "`TaskGet`/`TaskList` is used before dispatching sub-steps in `implement` to verify prior task state"
+    done: false
+  - item: "No Task is left in an unresolved state after a skill exits (success or failure)"
+    done: false
 ---
 
 # Universal Task Tool Integration
@@ -170,12 +184,3 @@ A stopped Task is terminal — it cannot be resumed. If the user chooses to retr
 - **`setup-new-project`:** Onboarding utility, not a repeating workflow.
 - **Principle skills** (`commit-principles`, `core-principles`, etc.): Reference material, not processes.
 - **`principles-reviewer` agent:** Not a skill.
-
-## Done When
-
-- [ ] All listed skills create Tasks at the step level on invocation
-- [ ] Every listed skill checks `TaskList` at start and presents resume/fresh-start choice when open Tasks exist
-- [ ] `TaskStop` is called on all failure and cancellation paths
-- [ ] `implement` creates a parent Task and instructs each dispatched subagent to create a child Task
-- [ ] `TaskGet`/`TaskList` is used before dispatching sub-steps in `implement` to verify prior task state
-- [ ] No Task is left in an unresolved state after a skill exits (success or failure)

--- a/docs/specs/2026-04-19-hexis-rename-design.md
+++ b/docs/specs/2026-04-19-hexis-rename-design.md
@@ -1,6 +1,9 @@
-# Rename hw0k-workflow to hexis
+---
+issue: 25
+plan: docs/plans/2026-04-19-hexis-rename.md
+---
 
-Issue: #25
+# Rename hw0k-workflow to hexis
 
 ## Overview
 

--- a/docs/specs/2026-04-19-hexis-rename-design.md
+++ b/docs/specs/2026-04-19-hexis-rename-design.md
@@ -1,5 +1,6 @@
 ---
 issue: 25
+status: DONE
 ---
 
 # Rename hw0k-workflow to hexis
@@ -63,10 +64,3 @@ Skills: `commit-principles`, `core-principles`, `debug`, `dispatch`, `exception-
 
 - `docs/` directory (historical assets — do not modify, do not verify)
 - Personal config (`~/.claude/CLAUDE.md`, memory files) — updated as part of implementation but excluded from spec/plan documentation and repo grep check
-
-## Done When
-
-1. `grep -r "hw0k-workflow" . --exclude-dir=.git --exclude-dir=docs` returns zero matches
-2. `gh repo view --json nameWithOwner` returns `{"nameWithOwner":"hw0k/hexis"}`
-3. `gh issue view 22` body contains no `hw0k-workflow`
-4. `gh issue view 23` body contains no `hw0k-workflow`

--- a/docs/specs/2026-04-19-hexis-rename-design.md
+++ b/docs/specs/2026-04-19-hexis-rename-design.md
@@ -1,6 +1,5 @@
 ---
 issue: 25
-plan: docs/plans/2026-04-19-hexis-rename.md
 ---
 
 # Rename hw0k-workflow to hexis

--- a/docs/specs/2026-04-19-universal-skill-support-design.md
+++ b/docs/specs/2026-04-19-universal-skill-support-design.md
@@ -1,6 +1,9 @@
-# Universal Skill Support
+---
+issue: 16
+plan: docs/plans/2026-04-19-universal-skill-support.md
+---
 
-Issue: #16
+# Universal Skill Support
 
 ## What
 

--- a/docs/specs/2026-04-19-universal-skill-support-design.md
+++ b/docs/specs/2026-04-19-universal-skill-support-design.md
@@ -1,5 +1,19 @@
 ---
 issue: 16
+status: DONE
+checks:
+  - item: "`skills/platform-capabilities/SKILL.md` created with capability map (generic fallback column complete; platform-specific columns TBD-allowed)"
+    done: false
+  - item: "All 5 principle skills confirmed platform-agnostic (no changes, or documented changes if a reference is found)"
+    done: false
+  - item: "`specify` and `plan` updated: platform-specific tool references replaced with capability names and fallback notes"
+    done: false
+  - item: "`verify`, `review`, `receive-review` updated: platform-specific tool references replaced with capability names and fallback notes"
+    done: false
+  - item: "`implement`, `use-worktree`, `finish` updated: platform-specific tool references replaced with capability names; Pattern 2 applied for spawn-subagent and worktree"
+    done: false
+  - item: "Pressure test scenario added at `tests/pressure/universal-skill-support/`"
+    done: false
 ---
 
 # Universal Skill Support
@@ -93,12 +107,3 @@ Replace platform-specific tool references with capability names. Add explicit co
 - `dispatch`, `sync-working-status`, `debug`, `setup-new-project`, `write-test` — deferred to a follow-up
 - Resolving all TBD entries in the capability map before shipping
 - Per-platform SKILL.md file splits
-
-## Done When
-
-- [ ] `skills/platform-capabilities/SKILL.md` created with capability map (generic fallback column complete; platform-specific columns TBD-allowed)
-- [ ] All 5 principle skills confirmed platform-agnostic (no changes, or documented changes if a reference is found)
-- [ ] `specify` and `plan` updated: platform-specific tool references replaced with capability names and fallback notes
-- [ ] `verify`, `review`, `receive-review` updated: platform-specific tool references replaced with capability names and fallback notes
-- [ ] `implement`, `use-worktree`, `finish` updated: platform-specific tool references replaced with capability names; Pattern 2 applied for spawn-subagent and worktree
-- [ ] Pressure test scenario added at `tests/pressure/universal-skill-support/`

--- a/docs/specs/2026-04-19-universal-skill-support-design.md
+++ b/docs/specs/2026-04-19-universal-skill-support-design.md
@@ -1,6 +1,5 @@
 ---
 issue: 16
-plan: docs/plans/2026-04-19-universal-skill-support.md
 ---
 
 # Universal Skill Support

--- a/docs/specs/2026-04-22-tdd-workflow-restructure-design.md
+++ b/docs/specs/2026-04-22-tdd-workflow-restructure-design.md
@@ -1,5 +1,19 @@
 ---
 issue: 27
+status: DONE
+checks:
+  - item: "`skills/write-test/` directory does not exist"
+    done: true
+  - item: "`skills/testing-principles/SKILL.md` exists with all sections listed above"
+    done: true
+  - item: "`skills/plan/SKILL.md` includes TDD applicability criteria and both TDD/non-TDD step structures"
+    done: true
+  - item: "`skills/implement/SKILL.md` references testing-principles for TDD tasks"
+    done: true
+  - item: "`agents/principles-reviewer.md` includes testing-principles in scope and output"
+    done: true
+  - item: "All changes committed; no references to `hexis:write-test` remain in the repo"
+    done: true
 ---
 
 # TDD Workflow Restructure — Remove write-test, add testing-principles
@@ -138,12 +152,3 @@ Note: testing-principles is a reference skill, not a process enforcement skill �
 - Changes to `hexis:dispatch` routing — dispatch already routes plan → implement; write-test was never in the routing table
 - Changes to `hexis:specify` — TDD is a plan/implement concern
 - Changes to `hexis:verify` — post-implementation verification is separate
-
-## Done Criteria
-
-- `skills/write-test/` directory does not exist
-- `skills/testing-principles/SKILL.md` exists with all sections listed above
-- `skills/plan/SKILL.md` includes TDD applicability criteria and both TDD/non-TDD step structures
-- `skills/implement/SKILL.md` references testing-principles for TDD tasks
-- `agents/principles-reviewer.md` includes testing-principles in scope and output
-- All changes committed; no references to `hexis:write-test` remain in the repo

--- a/docs/specs/2026-04-22-tdd-workflow-restructure-design.md
+++ b/docs/specs/2026-04-22-tdd-workflow-restructure-design.md
@@ -1,6 +1,5 @@
 ---
 issue: 27
-plan: docs/plans/2026-04-22-tdd-workflow-restructure.md
 ---
 
 # TDD Workflow Restructure — Remove write-test, add testing-principles

--- a/docs/specs/2026-04-22-tdd-workflow-restructure-design.md
+++ b/docs/specs/2026-04-22-tdd-workflow-restructure-design.md
@@ -1,6 +1,9 @@
-# TDD Workflow Restructure — Remove write-test, add testing-principles
+---
+issue: 27
+plan: docs/plans/2026-04-22-tdd-workflow-restructure.md
+---
 
-Issue: #27
+# TDD Workflow Restructure — Remove write-test, add testing-principles
 
 ## Problem
 

--- a/docs/specs/2026-04-23-document-formats-design.md
+++ b/docs/specs/2026-04-23-document-formats-design.md
@@ -1,0 +1,171 @@
+---
+issue: 20
+---
+
+# Standardize Spec and Plan Document Formats
+
+## Problem
+
+`docs/specs/` and `docs/plans/` exist as conventions, but their internal structure is undocumented. Skills that produce or consume these files (`specify`, `plan`, `dispatch`, `sync-working-status`) each hold implicit assumptions about the structure — assumptions that can diverge silently.
+
+Two specific gaps:
+
+1. **Inconsistent machine-readable markers.** Spec files embed `Issue: #N` as a plain body line; plan files use `linked_spec` YAML frontmatter. There is no consistent contract for where machine-readable fields live.
+2. **No shared source of truth for format.** Skills describe their output format inline and independently, so structural drift goes undetected.
+
+## Goal
+
+Define a canonical format for spec files and plan files, with all machine-readable fields in YAML frontmatter. Encode these formats in `docs/templates/` as the single source of truth. Update all skills that produce or consume these files to reference the templates. Apply the new format to all existing files.
+
+Issue body format and PR description format are **out of scope** — those follow each team's or project's own conventions.
+
+## Changes
+
+### 1. `docs/templates/spec.md` — canonical spec format
+
+```markdown
+---
+issue: N
+plan: docs/plans/<filename>.md
+---
+
+# <Title>
+
+## Problem
+
+## Goal
+
+## Changes
+
+## Out of Scope
+
+## Done Criteria
+```
+
+**Frontmatter fields:**
+- `issue: N` — required when linked to a GitHub issue (bare integer, no `#`)
+- `plan: docs/plans/...` — optional; added by the `plan` skill once the plan file is created
+
+**Body sections:**
+- `## Problem` — required
+- `## Goal` — required
+- `## Changes` — required
+- `## Out of Scope` — optional
+- `## Done Criteria` — required
+
+**Removed:** `Issue: #N` as a body line (replaced by frontmatter `issue: N`).
+
+---
+
+### 2. `docs/templates/plan.md` — canonical plan format
+
+```markdown
+---
+linked_spec: docs/specs/<filename>.md
+issue: N
+---
+
+# <Title> Implementation Plan
+
+> **For agentic workers:** ...
+
+**Goal:** ...
+**Architecture:** ...
+**Tech Stack:** ...
+
+---
+
+## File Structure
+
+---
+
+### Task N: <Name> [TDD] or [No TDD — <reason>]
+...
+```
+
+**Frontmatter fields:**
+- `linked_spec: docs/specs/...` — required
+- `issue: N` — required when linked to a GitHub issue (new field; bare integer)
+
+**Body structure** follows the existing `plan` skill conventions (Goal, Architecture, Tech Stack, File Structure, tasks with TDD labels).
+
+---
+
+### 3. `skills/specify/SKILL.md`
+
+- Step 4 (Write and Commit): output file must match `docs/templates/spec.md`
+- Frontmatter must include `issue: N` — replaces `Issue: #N` body line
+- Remove instruction to write `Issue: #N` in the body
+
+---
+
+### 4. `skills/plan/SKILL.md`
+
+- Plan output must match `docs/templates/plan.md`
+- Frontmatter must include `issue: N` (in addition to existing `linked_spec`)
+- After creating the plan file, update the spec's frontmatter to add `plan: docs/plans/<filename>.md`
+
+---
+
+### 5. `skills/dispatch/SKILL.md`
+
+Current grep:
+```bash
+grep -rl "#N" docs/specs/ 2>/dev/null
+grep -rl "#N" docs/plans/ 2>/dev/null
+```
+
+Replace with:
+```bash
+grep -rl "^issue: N$" docs/specs/ 2>/dev/null
+grep -rl "^issue: N$" docs/plans/ 2>/dev/null
+```
+
+Where `N` is the literal issue number (e.g., `^issue: 20$`).
+
+---
+
+### 6. `skills/sync-working-status/SKILL.md`
+
+- When verifying the "1 Spec = 1 Issue" invariant, locate spec/plan files by matching frontmatter `issue: N` rather than scanning filenames.
+
+---
+
+### 7. `skills/review/SKILL.md`
+
+- Add a note: spec and plan files consumed during review follow the formats in `docs/templates/spec.md` and `docs/templates/plan.md`.
+
+---
+
+### 8. Backfill all existing spec and plan files
+
+Apply the new format to all files in `docs/specs/` (17 files) and `docs/plans/` (12 files):
+
+- **Spec files**: add YAML frontmatter with `issue: N` (extract N from existing `Issue: #N` body line), then remove the `Issue: #N` body line. Add `plan:` field if a corresponding plan file exists.
+- **Plan files**: add `issue: N` to existing frontmatter. Add `issue:` based on the issue number referenced in the linked spec.
+- Files with no linked issue: add frontmatter block without `issue:` field (just `linked_spec:` for plans, empty frontmatter `---\n---` for standalone specs).
+
+---
+
+### 9. Delete `docs/templates/issue.md` and `docs/templates/pr.md`
+
+These were created during spec drafting but are out of scope. Remove them.
+
+## Out of Scope
+
+- Issue body format
+- PR description format
+- GitHub-native templates (`.github/ISSUE_TEMPLATE/`, `.github/PULL_REQUEST_TEMPLATE.md`)
+- Backfilling is full-scope (all existing files, not just open issues)
+
+## Done Criteria
+
+- `docs/templates/spec.md` defines canonical spec format with frontmatter
+- `docs/templates/plan.md` defines canonical plan format with frontmatter including `issue: N`
+- `docs/templates/issue.md` and `docs/templates/pr.md` deleted
+- `skills/specify/SKILL.md` outputs spec with frontmatter `issue: N`; no longer writes `Issue: #N` in body
+- `skills/plan/SKILL.md` outputs plan with frontmatter `issue: N`; adds `plan:` back-link to spec frontmatter
+- `skills/dispatch/SKILL.md` greps `^issue: N$` in frontmatter instead of `#N` in body
+- `skills/sync-working-status/SKILL.md` locates spec/plan by frontmatter `issue: N`
+- `skills/review/SKILL.md` references `docs/templates/` for expected format
+- All 17 spec files and 12 plan files updated to match new format

--- a/docs/specs/2026-04-23-document-formats-design.md
+++ b/docs/specs/2026-04-23-document-formats-design.md
@@ -1,5 +1,21 @@
 ---
 issue: 20
+status: IN_PROGRESS
+checks:
+  - item: "`issue: N` — required when linked to a GitHub issue (bare integer, no `#`)"
+    done: false
+  - item: "`plan: docs/plans/...` — optional; added by the `plan` skill once the plan file is created"
+    done: false
+  - item: "`## Problem` — required"
+    done: false
+  - item: "`## Goal` — required"
+    done: false
+  - item: "`## Changes` — required"
+    done: false
+  - item: "`## Out of Scope` — optional"
+    done: false
+  - item: "`## Done Criteria` — required"
+    done: false
 ---
 
 # Standardize Spec and Plan Document Formats
@@ -37,24 +53,6 @@ issue: N
 ## Changes
 
 ## Out of Scope
-
-## Done Criteria
-```
-
-**Frontmatter fields:**
-- `issue: N` — required when linked to a GitHub issue (bare integer, no `#`)
-- `plan: docs/plans/...` — optional; added by the `plan` skill once the plan file is created
-
-**Body sections:**
-- `## Problem` — required
-- `## Goal` — required
-- `## Changes` — required
-- `## Out of Scope` — optional
-- `## Done Criteria` — required
-
-**Removed:** `Issue: #N` as a body line (replaced by frontmatter `issue: N`).
-
----
 
 ### 2. `docs/templates/plan.md` — canonical plan format
 

--- a/docs/specs/2026-04-23-document-formats-design.md
+++ b/docs/specs/2026-04-23-document-formats-design.md
@@ -1,5 +1,6 @@
 ---
 issue: 20
+plan: docs/plans/2026-04-23-document-formats.md
 ---
 
 # Standardize Spec and Plan Document Formats

--- a/docs/specs/2026-04-23-document-formats-design.md
+++ b/docs/specs/2026-04-23-document-formats-design.md
@@ -1,6 +1,5 @@
 ---
 issue: 20
-plan: docs/plans/2026-04-23-document-formats.md
 ---
 
 # Standardize Spec and Plan Document Formats
@@ -27,7 +26,6 @@ Issue body format and PR description format are **out of scope** — those follo
 ```markdown
 ---
 issue: N
-plan: docs/plans/<filename>.md
 ---
 
 # <Title>

--- a/docs/templates/plan.md
+++ b/docs/templates/plan.md
@@ -1,6 +1,7 @@
 ---
-linked_spec: docs/specs/<filename>.md
 issue: N
+status: READY_TO_IMPLEMENT
+linked_spec: docs/specs/<filename>.md
 ---
 
 # <Title> Implementation Plan

--- a/docs/templates/plan.md
+++ b/docs/templates/plan.md
@@ -1,0 +1,37 @@
+---
+linked_spec: docs/specs/<filename>.md
+issue: N
+---
+
+# <Title> Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `hexis:implement` to execute task by task. For TDD tasks, follow `hexis:testing-principles`. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:**
+
+**Architecture:**
+
+**Tech Stack:**
+
+---
+
+## File Structure
+
+---
+
+### Task N: <Name> [TDD] or [No TDD — <reason>]
+
+**Files:**
+- Create/Modify/Delete: `exact/path/to/file`
+
+**TDD step structure:**
+- [ ] **Step 1: Write failing test**
+- [ ] **Step 2: Confirm failure** (run: `<command>`, Expected: FAIL — `<message>`)
+- [ ] **Step 3: Minimal implementation**
+- [ ] **Step 4: Confirm pass** (run: `<command>`, Expected: PASS)
+- [ ] **Step 5: Commit**
+
+**Non-TDD step structure:**
+- [ ] **Step 1: Implement**
+- [ ] **Step 2: Verify** (run: `<command>`, Expected: `<output>`)
+- [ ] **Step 3: Commit**

--- a/docs/templates/spec.md
+++ b/docs/templates/spec.md
@@ -1,0 +1,16 @@
+---
+issue: N
+plan: docs/plans/<filename>.md
+---
+
+# <Title>
+
+## Problem
+
+## Goal
+
+## Changes
+
+## Out of Scope
+
+## Done Criteria

--- a/docs/templates/spec.md
+++ b/docs/templates/spec.md
@@ -1,6 +1,5 @@
 ---
 issue: N
-plan: docs/plans/<filename>.md
 ---
 
 # <Title>

--- a/docs/templates/spec.md
+++ b/docs/templates/spec.md
@@ -1,5 +1,9 @@
 ---
 issue: N
+status: READY_TO_PLAN
+checks:
+  - item: "acceptance criterion here"
+    done: false
 ---
 
 # <Title>
@@ -11,5 +15,3 @@ issue: N
 ## Changes
 
 ## Out of Scope
-
-## Done Criteria

--- a/skills/dispatch/SKILL.md
+++ b/skills/dispatch/SKILL.md
@@ -54,14 +54,16 @@ Use `AskUserQuestion` to ask: "What issue number are you working on? Enter the n
 Run in parallel:
 
 ```bash
-grep -rl "#N" docs/specs/ 2>/dev/null
-grep -rl "#N" docs/plans/ 2>/dev/null
+grep -rl "^issue: N$" docs/specs/ 2>/dev/null
+grep -rl "^issue: N$" docs/plans/ 2>/dev/null
 gh pr list --head $(git branch --show-current) --json number,state,isDraft,reviewDecision,statusCheckRollup --limit 1
 ```
 
+Where `N` is the literal issue number (e.g., for issue 20: `grep -rl "^issue: 20$" docs/specs/ 2>/dev/null`).
+
 Collect:
-- `spec_found`: true if any file in `docs/specs/` contains `#N`
-- `plan_found`: true if any file in `docs/plans/` contains `#N`
+- `spec_found`: true if any file in `docs/specs/` has frontmatter line `issue: N`
+- `plan_found`: true if any file in `docs/plans/` has frontmatter line `issue: N`
 - `pr`: the PR object from `gh`, or empty if none
 
 ## Step 2: Routing
@@ -111,5 +113,5 @@ Then immediately invoke the determined skill. No confirmation prompt.
 
 ## Notes
 
-- If spec/plan files do not embed `Issue: #N` in their content, dispatch cannot locate them — they are treated as non-existent, and dispatch routes to `specify` or `plan` accordingly.
+- If spec/plan files do not have `issue: N` in their YAML frontmatter, dispatch cannot locate them — they are treated as non-existent, and dispatch routes to `specify` or `plan` accordingly.
 - Multiple issues on one branch: dispatch uses the first integer found in the branch name. If this is wrong, pass the correct issue number when asked.

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -187,8 +187,7 @@ After writing: spec coverage, placeholder scan, type/method name consistency.
 
 ## Save
 
-1. Write `docs/plans/YYYY-MM-DD-<feature>.md`. Commit: `docs: add <feature> plan`.
-2. Update the linked spec's YAML frontmatter: add `plan: docs/plans/<filename>.md`. Commit: `docs: add plan back-link to <topic> spec (#N)`.
+`docs/plans/YYYY-MM-DD-<feature>.md`. Commit: `docs: add <feature> plan`.
 
 ## Execution Handoff
 

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -60,6 +60,7 @@ Every plan must start with this header:
 ```markdown
 ---
 linked_spec: docs/specs/YYYY-MM-DD-<topic>-design.md
+issue: N
 ---
 
 # [Feature Name] Implementation Plan
@@ -186,7 +187,8 @@ After writing: spec coverage, placeholder scan, type/method name consistency.
 
 ## Save
 
-`docs/plans/YYYY-MM-DD-<feature>.md`. Commit: `docs: add <feature> plan`.
+1. Write `docs/plans/YYYY-MM-DD-<feature>.md`. Commit: `docs: add <feature> plan`.
+2. Update the linked spec's YAML frontmatter: add `plan: docs/plans/<filename>.md`. Commit: `docs: add plan back-link to <topic> spec (#N)`.
 
 ## Execution Handoff
 

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -59,8 +59,9 @@ Every plan must start with this header:
 
 ```markdown
 ---
-linked_spec: docs/specs/YYYY-MM-DD-<topic>-design.md
 issue: N
+status: READY_TO_IMPLEMENT
+linked_spec: docs/specs/YYYY-MM-DD-<topic>-design.md
 ---
 
 # [Feature Name] Implementation Plan

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -81,3 +81,4 @@ Use the **spawn-subagent** capability to run the `hexis:principles-reviewer` age
 - Request review while verify is failing
 - Ignore principle violations
 - Skip review because "it's simple"
+- Spec or plan files in the diff that don't follow `docs/templates/spec.md` / `docs/templates/plan.md`

--- a/skills/specify/SKILL.md
+++ b/skills/specify/SKILL.md
@@ -100,12 +100,18 @@ Write to `docs/specs/YYYY-MM-DD-<topic>-design.md`. The file must match `docs/te
 ```markdown
 ---
 issue: N
+status: READY_TO_PLAN
+checks:
+  - item: "criterion description"
+    done: false
 ---
 
 # <Title>
 ```
 
-Where `N` is the GitHub issue number this spec addresses (bare integer, no `#`). If there is no associated issue, omit the frontmatter. The `issue: N` frontmatter field is required for `hexis:dispatch` to locate the spec by issue number.
+Where `N` is the GitHub issue number this spec addresses (bare integer, no `#`). If there is no associated issue, omit `issue:`. The `issue: N` frontmatter field is required for `hexis:dispatch` to locate the spec by issue number.
+
+**HARD RULE:** The `## Done Criteria` body section is FORBIDDEN. All acceptance criteria MUST be defined in `checks:` frontmatter as a list of `{item, done}` objects. A spec file with a `## Done Criteria` body section is malformed.
 
 Commit: `docs: add <topic> spec`
 

--- a/skills/specify/SKILL.md
+++ b/skills/specify/SKILL.md
@@ -95,15 +95,17 @@ A good spec answers:
 
 **MANDATORY — do this immediately after approval, before anything else.**
 
-Write to `docs/specs/YYYY-MM-DD-<topic>-design.md`. The file must begin with:
+Write to `docs/specs/YYYY-MM-DD-<topic>-design.md`. The file must match `docs/templates/spec.md`. The file must begin with:
 
 ```markdown
-# <Title>
+---
+issue: N
+---
 
-Issue: #N
+# <Title>
 ```
 
-Where `N` is the GitHub issue number this spec addresses. If there is no associated issue, omit the `Issue:` line. This line is required for `hexis:dispatch` to locate the spec by issue number.
+Where `N` is the GitHub issue number this spec addresses (bare integer, no `#`). If there is no associated issue, omit the frontmatter. The `issue: N` frontmatter field is required for `hexis:dispatch` to locate the spec by issue number.
 
 Commit: `docs: add <topic> spec`
 

--- a/skills/sync-working-status/SKILL.md
+++ b/skills/sync-working-status/SKILL.md
@@ -48,8 +48,8 @@ Also verify the **1 Spec = 1 Issue** invariant:
 # List open issues
 gh issue list --state open --json number,title
 
-# List spec files
-ls docs/specs/
+# List spec files with their issue numbers
+grep -rn "^issue: " docs/specs/
 ```
 
 - For each open issue: is there a corresponding Spec file (matching issue number in frontmatter)?


### PR DESCRIPTION
## Summary
- Defines canonical formats for spec and plan files in `docs/templates/` as the single source of truth
- Moves all machine-readable fields to YAML frontmatter (`issue: N` in specs, `issue: N` + `linked_spec:` in plans)
- Updates `specify`, `plan`, `dispatch`, `sync-working-status`, `review` skills to use the new frontmatter convention
- Backfills all existing 17 spec files and 12 plan files to match the new format

## Test Plan
- [ ] `docs/templates/spec.md` has only `issue: N` in frontmatter (no `plan:` field)
- [ ] `docs/templates/plan.md` has `linked_spec:` and `issue: N` in frontmatter
- [ ] `grep -rl "^Issue: #" docs/specs/` returns no results
- [ ] `grep -rn "^issue: " docs/specs/` returns all spec files with issue numbers
- [ ] `skills/dispatch/SKILL.md` uses `grep -rl "^issue: N$"` instead of `#N`

Closes #20