### PR TITLE
feat: hexis CLI tool — stateless workflow state reporter (#22)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 .worktrees/
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.venv/

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "hexis"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+    "typer[all]>=0.9.0",
+    "pyyaml>=6.0",
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=7.0"]
+
+[project.scripts]
+hexis = "hexis.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/hexis"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/cli/src/hexis/cli.py
+++ b/cli/src/hexis/cli.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+import typer
+
+app = typer.Typer()
+status_app = typer.Typer()
+app.add_typer(status_app, name="status")

--- a/cli/src/hexis/cli.py
+++ b/cli/src/hexis/cli.py
@@ -1,6 +1,70 @@
 from __future__ import annotations
+import json as json_lib
+from pathlib import Path
+
 import typer
+
+from hexis.parser import MultipleMatchError
+from hexis.state import State, StateResult, determine_state
 
 app = typer.Typer()
 status_app = typer.Typer()
 app.add_typer(status_app, name="status")
+
+
+def _render_plain(result: StateResult) -> None:
+    typer.echo(f"STATE: {result.state.value}")
+    typer.echo(f"ISSUE: {result.issue}")
+    depends_str = ", ".join(f"#{n}" for n in result.depends_on) if result.depends_on else "(none)"
+    typer.echo(f"DEPENDS ON: {depends_str}")
+
+    if result.state in (State.NEEDS_SPEC, State.NEEDS_PLAN):
+        typer.echo("")
+        typer.echo("BLOCKING:")
+        for b in result.blocking:
+            typer.echo(f"  {b}")
+        return
+
+    if result.plan_tasks is not None:
+        typer.echo("")
+        typer.echo(f"PLAN TASKS: {result.plan_tasks.complete}/{result.plan_tasks.total} complete")
+
+    typer.echo("")
+    typer.echo("CHECKS:")
+    for c in result.checks:
+        mark = "x" if c.checked else " "
+        typer.echo(f"  [{mark}] #{c.index}  {c.text}")
+
+
+@status_app.command("read")
+def status_read(
+    issue: int,
+    json: bool = typer.Option(False, "--json"),
+    root: Path = typer.Option(Path("."), "--root"),
+) -> None:
+    root = root.resolve()
+    try:
+        result = determine_state(root, issue)
+    except MultipleMatchError as e:
+        typer.echo(str(e), err=True)
+        raise typer.Exit(2)
+
+    if json:
+        output = {
+            "state": result.state.value,
+            "issue": result.issue,
+            "depends_on": result.depends_on,
+            "plan_tasks": (
+                {"complete": result.plan_tasks.complete, "total": result.plan_tasks.total}
+                if result.plan_tasks is not None
+                else None
+            ),
+            "checks": [
+                {"index": c.index, "text": c.text, "checked": c.checked}
+                for c in result.checks
+            ],
+            "blocking": result.blocking,
+        }
+        typer.echo(json_lib.dumps(output, indent=2))
+    else:
+        _render_plain(result)

--- a/cli/src/hexis/cli.py
+++ b/cli/src/hexis/cli.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import typer
 
-from hexis.parser import MultipleMatchError
+from hexis.parser import MultipleMatchError, find_spec_file, parse_frontmatter, write_checks
 from hexis.state import State, StateResult, determine_state
 
 app = typer.Typer()
@@ -68,3 +68,54 @@ def status_read(
         typer.echo(json_lib.dumps(output, indent=2))
     else:
         _render_plain(result)
+
+
+@status_app.command("update")
+def status_update(
+    issue: int,
+    checked: str = typer.Option(..., "--checked"),
+    unchecked: str = typer.Option(..., "--unchecked"),
+    root: Path = typer.Option(Path("."), "--root"),
+) -> None:
+    root = root.resolve()
+
+    try:
+        checked_idx = [int(i.strip()) for i in checked.split(",") if i.strip()]
+        unchecked_idx = [int(i.strip()) for i in unchecked.split(",") if i.strip()]
+    except ValueError:
+        typer.echo("Error: indices must be integers", err=True)
+        raise typer.Exit(1)
+
+    all_idx = sorted(checked_idx + unchecked_idx)
+
+    try:
+        spec_path = find_spec_file(root, issue)
+    except MultipleMatchError as e:
+        typer.echo(str(e), err=True)
+        raise typer.Exit(2)
+
+    if spec_path is None:
+        typer.echo(f"No spec file found for issue #{issue}", err=True)
+        raise typer.Exit(1)
+
+    fm = parse_frontmatter(spec_path.read_text())
+    n = len(fm.get("checks") or [])
+    expected = list(range(n))
+
+    if all_idx != expected:
+        typer.echo(
+            f"Error: indices {all_idx} do not cover all {n} checks exactly once "
+            f"(expected {expected})",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    checked_set = set(checked_idx)
+    new_checks = [
+        {"item": c["item"], "done": i in checked_set}
+        for i, c in enumerate(fm["checks"])
+    ]
+    write_checks(spec_path, new_checks)
+
+    result = determine_state(root, issue)
+    _render_plain(result)

--- a/cli/src/hexis/parser.py
+++ b/cli/src/hexis/parser.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 from dataclasses import dataclass
+import os
 from pathlib import Path
 import re
+import tempfile
 import yaml
 
 
@@ -79,3 +81,19 @@ def parse_plan_tasks(content: str) -> PlanTasks:
     checked = len(re.findall(r"^- \[x\]", body, re.MULTILINE))
     unchecked = len(re.findall(r"^- \[ \]", body, re.MULTILINE))
     return PlanTasks(complete=checked, total=checked + unchecked)
+
+
+def write_checks(path: Path, new_checks: list[dict]) -> None:
+    content = path.read_text()
+    end = content.find("\n---\n", 4)
+    fm = yaml.safe_load(content[4:end]) or {}
+    body = content[end + 5:]
+    fm["checks"] = new_checks
+    new_fm = yaml.dump(fm, default_flow_style=False, allow_unicode=True, sort_keys=False)
+    new_content = f"---\n{new_fm}---\n{body}"
+    with tempfile.NamedTemporaryFile(
+        mode="w", dir=path.parent, delete=False, suffix=".tmp", encoding="utf-8"
+    ) as f:
+        f.write(new_content)
+        tmp = f.name
+    os.replace(tmp, path)

--- a/cli/src/hexis/parser.py
+++ b/cli/src/hexis/parser.py
@@ -5,6 +5,13 @@ import re
 import yaml
 
 
+@dataclass
+class Check:
+    index: int
+    text: str
+    checked: bool
+
+
 def parse_frontmatter(content: str) -> dict:
     if not content.startswith("---\n"):
         return {}
@@ -44,3 +51,14 @@ def find_plan_file(root: Path, issue: int) -> Path | None:
         names = ", ".join(p.name for p in sorted(matches))
         raise MultipleMatchError(f"Multiple plan files match issue #{issue}: {names}")
     return matches[0] if matches else None
+
+
+def parse_checks(fm: dict) -> list[Check]:
+    return [
+        Check(index=i, text=c["item"], checked=bool(c["done"]))
+        for i, c in enumerate(fm.get("checks") or [])
+    ]
+
+
+def parse_depends_on(fm: dict) -> list[int]:
+    return list(fm.get("depends_on") or [])

--- a/cli/src/hexis/parser.py
+++ b/cli/src/hexis/parser.py
@@ -3,3 +3,12 @@ from dataclasses import dataclass
 from pathlib import Path
 import re
 import yaml
+
+
+def parse_frontmatter(content: str) -> dict:
+    if not content.startswith("---\n"):
+        return {}
+    end = content.find("\n---\n", 4)
+    if end == -1:
+        return {}
+    return yaml.safe_load(content[4:end]) or {}

--- a/cli/src/hexis/parser.py
+++ b/cli/src/hexis/parser.py
@@ -12,6 +12,12 @@ class Check:
     checked: bool
 
 
+@dataclass
+class PlanTasks:
+    complete: int
+    total: int
+
+
 def parse_frontmatter(content: str) -> dict:
     if not content.startswith("---\n"):
         return {}
@@ -62,3 +68,14 @@ def parse_checks(fm: dict) -> list[Check]:
 
 def parse_depends_on(fm: dict) -> list[int]:
     return list(fm.get("depends_on") or [])
+
+
+def parse_plan_tasks(content: str) -> PlanTasks:
+    body = content
+    if content.startswith("---\n"):
+        end = content.find("\n---\n", 4)
+        if end != -1:
+            body = content[end + 5:]
+    checked = len(re.findall(r"^- \[x\]", body, re.MULTILINE))
+    unchecked = len(re.findall(r"^- \[ \]", body, re.MULTILINE))
+    return PlanTasks(complete=checked, total=checked + unchecked)

--- a/cli/src/hexis/parser.py
+++ b/cli/src/hexis/parser.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from pathlib import Path
+import re
+import yaml

--- a/cli/src/hexis/parser.py
+++ b/cli/src/hexis/parser.py
@@ -12,3 +12,35 @@ def parse_frontmatter(content: str) -> dict:
     if end == -1:
         return {}
     return yaml.safe_load(content[4:end]) or {}
+
+
+class MultipleMatchError(Exception):
+    pass
+
+
+def find_spec_file(root: Path, issue: int) -> Path | None:
+    specs_dir = root / "docs" / "specs"
+    if not specs_dir.is_dir():
+        return None
+    matches = [
+        p for p in specs_dir.glob("*.md")
+        if parse_frontmatter(p.read_text()).get("issue") == issue
+    ]
+    if len(matches) > 1:
+        names = ", ".join(p.name for p in sorted(matches))
+        raise MultipleMatchError(f"Multiple spec files match issue #{issue}: {names}")
+    return matches[0] if matches else None
+
+
+def find_plan_file(root: Path, issue: int) -> Path | None:
+    plans_dir = root / "docs" / "plans"
+    if not plans_dir.is_dir():
+        return None
+    matches = [
+        p for p in plans_dir.glob("*.md")
+        if parse_frontmatter(p.read_text()).get("issue") == issue
+    ]
+    if len(matches) > 1:
+        names = ", ".join(p.name for p in sorted(matches))
+        raise MultipleMatchError(f"Multiple plan files match issue #{issue}: {names}")
+    return matches[0] if matches else None

--- a/cli/src/hexis/state.py
+++ b/cli/src/hexis/state.py
@@ -2,3 +2,85 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
+
+from hexis.parser import (
+    Check,
+    PlanTasks,
+    MultipleMatchError,
+    find_spec_file,
+    find_plan_file,
+    parse_frontmatter,
+    parse_checks,
+    parse_depends_on,
+    parse_plan_tasks,
+)
+
+
+class State(str, Enum):
+    NEEDS_SPEC = "NEEDS_SPEC"
+    NEEDS_PLAN = "NEEDS_PLAN"
+    IN_PROGRESS = "IN_PROGRESS"
+    NEEDS_VERIFY = "NEEDS_VERIFY"
+    DONE = "DONE"
+
+
+@dataclass
+class StateResult:
+    state: State
+    issue: int
+    depends_on: list[int] = field(default_factory=list)
+    plan_tasks: PlanTasks | None = None
+    checks: list[Check] = field(default_factory=list)
+    blocking: list[str] = field(default_factory=list)
+
+
+def determine_state(root: Path, issue: int) -> StateResult:
+    spec_path = find_spec_file(root, issue)
+    if spec_path is None:
+        return StateResult(
+            state=State.NEEDS_SPEC,
+            issue=issue,
+            blocking=[f"No spec file found in docs/specs/ for issue #{issue}"],
+        )
+
+    spec_fm = parse_frontmatter(spec_path.read_text())
+    checks = parse_checks(spec_fm)
+    depends_on = parse_depends_on(spec_fm)
+
+    plan_path = find_plan_file(root, issue)
+    if plan_path is None:
+        return StateResult(
+            state=State.NEEDS_PLAN,
+            issue=issue,
+            depends_on=depends_on,
+            checks=checks,
+            blocking=[f"No plan file found in docs/plans/ for issue #{issue}"],
+        )
+
+    plan_tasks = parse_plan_tasks(plan_path.read_text())
+
+    if plan_tasks.total > 0 and plan_tasks.complete < plan_tasks.total:
+        return StateResult(
+            state=State.IN_PROGRESS,
+            issue=issue,
+            depends_on=depends_on,
+            plan_tasks=plan_tasks,
+            checks=checks,
+        )
+
+    if any(not c.checked for c in checks):
+        return StateResult(
+            state=State.NEEDS_VERIFY,
+            issue=issue,
+            depends_on=depends_on,
+            plan_tasks=plan_tasks,
+            checks=checks,
+        )
+
+    return StateResult(
+        state=State.DONE,
+        issue=issue,
+        depends_on=depends_on,
+        plan_tasks=plan_tasks,
+        checks=checks,
+    )

--- a/cli/src/hexis/state.py
+++ b/cli/src/hexis/state.py
@@ -1,0 +1,4 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -67,3 +67,75 @@ def test_status_read_missing_docs_graceful(tmp_path):
     result = runner.invoke(app, ["status", "read", "99", "--root", str(tmp_path)])
     assert result.exit_code == 0
     assert "STATE: NEEDS_SPEC" in result.output
+
+
+from hexis.parser import parse_frontmatter
+
+
+def _setup_spec_with_plan(tmp_path, issue, checks_done):
+    specs_dir = tmp_path / "docs" / "specs"
+    plans_dir = tmp_path / "docs" / "plans"
+    specs_dir.mkdir(parents=True, exist_ok=True)
+    plans_dir.mkdir(parents=True, exist_ok=True)
+    checks_yaml = "\n".join(
+        f"  - item: Item {i}\n    done: {'true' if d else 'false'}"
+        for i, d in enumerate(checks_done)
+    )
+    spec_path = specs_dir / "spec.md"
+    spec_path.write_text(
+        f"---\nissue: {issue}\nchecks:\n{checks_yaml}\n---\n\n# Spec\n"
+    )
+    (plans_dir / "plan.md").write_text(
+        f"---\nissue: {issue}\n---\n\n- [x] Step 1\n"
+    )
+    return spec_path
+
+
+def test_status_update_sets_checked(tmp_path):
+    spec_path = _setup_spec_with_plan(tmp_path, 5, [False, False])
+    result = runner.invoke(
+        app,
+        ["status", "update", "5", "--checked", "0", "--unchecked", "1", "--root", str(tmp_path)],
+    )
+    assert result.exit_code == 0
+    fm = parse_frontmatter(spec_path.read_text())
+    assert fm["checks"][0]["done"] is True
+    assert fm["checks"][1]["done"] is False
+    assert "STATE:" in result.output
+
+
+def test_status_update_all_checked_yields_done(tmp_path):
+    _setup_spec_with_plan(tmp_path, 5, [False])
+    result = runner.invoke(
+        app,
+        ["status", "update", "5", "--checked", "0", "--unchecked", "", "--root", str(tmp_path)],
+    )
+    assert result.exit_code == 0
+    assert "STATE: DONE" in result.output
+
+
+def test_status_update_incomplete_coverage_exits_1(tmp_path):
+    _setup_spec_with_plan(tmp_path, 5, [False, False])
+    result = runner.invoke(
+        app,
+        ["status", "update", "5", "--checked", "0", "--unchecked", "", "--root", str(tmp_path)],
+    )
+    assert result.exit_code == 1
+
+
+def test_status_update_overlapping_indices_exits_1(tmp_path):
+    _setup_spec_with_plan(tmp_path, 5, [False, False])
+    result = runner.invoke(
+        app,
+        ["status", "update", "5", "--checked", "0,1", "--unchecked", "0", "--root", str(tmp_path)],
+    )
+    assert result.exit_code == 1
+
+
+def test_status_update_no_spec_exits_1(tmp_path):
+    (tmp_path / "docs" / "specs").mkdir(parents=True)
+    result = runner.invoke(
+        app,
+        ["status", "update", "99", "--checked", "", "--unchecked", "", "--root", str(tmp_path)],
+    )
+    assert result.exit_code == 1

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -1,0 +1,69 @@
+import json
+from typer.testing import CliRunner
+from hexis.cli import app
+
+runner = CliRunner()
+
+
+def _setup_needs_verify(tmp_path):
+    specs_dir = tmp_path / "docs" / "specs"
+    plans_dir = tmp_path / "docs" / "plans"
+    specs_dir.mkdir(parents=True)
+    plans_dir.mkdir(parents=True)
+    (specs_dir / "spec.md").write_text(
+        "---\nissue: 5\nchecks:\n  - item: A\n    done: false\n  - item: B\n    done: true\n---\n\n# Spec\n"
+    )
+    (plans_dir / "plan.md").write_text(
+        "---\nissue: 5\n---\n\n- [x] Step 1\n- [x] Step 2\n"
+    )
+
+
+def test_status_read_needs_spec_plain(tmp_path):
+    (tmp_path / "docs" / "specs").mkdir(parents=True)
+    result = runner.invoke(app, ["status", "read", "99", "--root", str(tmp_path)])
+    assert result.exit_code == 0
+    assert "STATE: NEEDS_SPEC" in result.output
+    assert "ISSUE: 99" in result.output
+    assert "DEPENDS ON: (none)" in result.output
+    assert "BLOCKING:" in result.output
+
+
+def test_status_read_needs_verify_plain(tmp_path):
+    _setup_needs_verify(tmp_path)
+    result = runner.invoke(app, ["status", "read", "5", "--root", str(tmp_path)])
+    assert result.exit_code == 0
+    assert "STATE: NEEDS_VERIFY" in result.output
+    assert "PLAN TASKS: 2/2 complete" in result.output
+    assert "CHECKS:" in result.output
+    assert "[ ] #0  A" in result.output
+    assert "[x] #1  B" in result.output
+
+
+def test_status_read_json_needs_spec(tmp_path):
+    (tmp_path / "docs" / "specs").mkdir(parents=True)
+    result = runner.invoke(app, ["status", "read", "99", "--json", "--root", str(tmp_path)])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["state"] == "NEEDS_SPEC"
+    assert data["issue"] == 99
+    assert data["depends_on"] == []
+    assert data["plan_tasks"] is None
+    assert data["checks"] == []
+    assert len(data["blocking"]) == 1
+
+
+def test_status_read_json_needs_verify(tmp_path):
+    _setup_needs_verify(tmp_path)
+    result = runner.invoke(app, ["status", "read", "5", "--json", "--root", str(tmp_path)])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["state"] == "NEEDS_VERIFY"
+    assert data["plan_tasks"] == {"complete": 2, "total": 2}
+    assert data["checks"][0] == {"index": 0, "text": "A", "checked": False}
+    assert data["checks"][1] == {"index": 1, "text": "B", "checked": True}
+
+
+def test_status_read_missing_docs_graceful(tmp_path):
+    result = runner.invoke(app, ["status", "read", "99", "--root", str(tmp_path)])
+    assert result.exit_code == 0
+    assert "STATE: NEEDS_SPEC" in result.output

--- a/cli/tests/test_parser.py
+++ b/cli/tests/test_parser.py
@@ -59,3 +59,36 @@ def test_find_plan_file_not_found(tmp_path):
 
 def test_find_plan_file_missing_dir(tmp_path):
     assert find_plan_file(tmp_path, 5) is None
+
+from hexis.parser import parse_checks, parse_depends_on, Check
+
+def test_parse_checks_mixed():
+    fm = {
+        "checks": [
+            {"item": "First criterion", "done": True},
+            {"item": "Second criterion", "done": False},
+        ]
+    }
+    result = parse_checks(fm)
+    assert result == [
+        Check(index=0, text="First criterion", checked=True),
+        Check(index=1, text="Second criterion", checked=False),
+    ]
+
+def test_parse_checks_empty_fm():
+    assert parse_checks({}) == []
+
+def test_parse_checks_preserves_order():
+    fm = {"checks": [{"item": "Z", "done": False}, {"item": "A", "done": True}]}
+    result = parse_checks(fm)
+    assert result[0].text == "Z"
+    assert result[1].text == "A"
+
+def test_parse_depends_on_list():
+    assert parse_depends_on({"depends_on": [22, 23]}) == [22, 23]
+
+def test_parse_depends_on_absent():
+    assert parse_depends_on({}) == []
+
+def test_parse_depends_on_null():
+    assert parse_depends_on({"depends_on": None}) == []

--- a/cli/tests/test_parser.py
+++ b/cli/tests/test_parser.py
@@ -15,3 +15,47 @@ def test_parse_frontmatter_no_frontmatter():
 
 def test_parse_frontmatter_incomplete_delimiter():
     assert parse_frontmatter("---\nissue: 5\n") == {}
+
+import pytest
+from hexis.parser import find_spec_file, find_plan_file, MultipleMatchError
+
+def test_find_spec_file_found(tmp_path):
+    specs_dir = tmp_path / "docs" / "specs"
+    specs_dir.mkdir(parents=True)
+    (specs_dir / "2026-01-01-foo-design.md").write_text(
+        "---\nissue: 5\nstatus: READY_TO_PLAN\n---\n\n# Foo\n"
+    )
+    result = find_spec_file(tmp_path, 5)
+    assert result is not None
+    assert result.name == "2026-01-01-foo-design.md"
+
+def test_find_spec_file_not_found(tmp_path):
+    (tmp_path / "docs" / "specs").mkdir(parents=True)
+    assert find_spec_file(tmp_path, 99) is None
+
+def test_find_spec_file_missing_dir(tmp_path):
+    assert find_spec_file(tmp_path, 5) is None
+
+def test_find_spec_file_multiple_raises(tmp_path):
+    specs_dir = tmp_path / "docs" / "specs"
+    specs_dir.mkdir(parents=True)
+    (specs_dir / "a.md").write_text("---\nissue: 5\n---\n\n# A\n")
+    (specs_dir / "b.md").write_text("---\nissue: 5\n---\n\n# B\n")
+    with pytest.raises(MultipleMatchError):
+        find_spec_file(tmp_path, 5)
+
+def test_find_plan_file_found(tmp_path):
+    plans_dir = tmp_path / "docs" / "plans"
+    plans_dir.mkdir(parents=True)
+    (plans_dir / "2026-01-01-foo.md").write_text(
+        "---\nissue: 5\nstatus: READY_TO_IMPLEMENT\n---\n\n# Foo Plan\n"
+    )
+    result = find_plan_file(tmp_path, 5)
+    assert result is not None
+
+def test_find_plan_file_not_found(tmp_path):
+    (tmp_path / "docs" / "plans").mkdir(parents=True)
+    assert find_plan_file(tmp_path, 99) is None
+
+def test_find_plan_file_missing_dir(tmp_path):
+    assert find_plan_file(tmp_path, 5) is None

--- a/cli/tests/test_parser.py
+++ b/cli/tests/test_parser.py
@@ -1,0 +1,17 @@
+from hexis.parser import parse_frontmatter
+
+def test_parse_frontmatter_valid():
+    content = "---\nissue: 5\nstatus: READY_TO_PLAN\n---\n\n# Title\n"
+    fm = parse_frontmatter(content)
+    assert fm == {"issue": 5, "status": "READY_TO_PLAN"}
+
+def test_parse_frontmatter_with_checks():
+    content = "---\nchecks:\n  - item: criterion\n    done: false\n---\n\n# Title\n"
+    fm = parse_frontmatter(content)
+    assert fm["checks"] == [{"item": "criterion", "done": False}]
+
+def test_parse_frontmatter_no_frontmatter():
+    assert parse_frontmatter("# Just a title\n") == {}
+
+def test_parse_frontmatter_incomplete_delimiter():
+    assert parse_frontmatter("---\nissue: 5\n") == {}

--- a/cli/tests/test_parser.py
+++ b/cli/tests/test_parser.py
@@ -92,3 +92,21 @@ def test_parse_depends_on_absent():
 
 def test_parse_depends_on_null():
     assert parse_depends_on({"depends_on": None}) == []
+
+from hexis.parser import parse_plan_tasks, PlanTasks
+
+def test_parse_plan_tasks_mixed():
+    content = "---\nissue: 5\n---\n\n- [x] Task one\n- [ ] Task two\n- [x] Task three\n"
+    assert parse_plan_tasks(content) == PlanTasks(complete=2, total=3)
+
+def test_parse_plan_tasks_all_done():
+    content = "---\nissue: 5\n---\n\n- [x] Task one\n- [x] Task two\n"
+    assert parse_plan_tasks(content) == PlanTasks(complete=2, total=2)
+
+def test_parse_plan_tasks_none():
+    content = "---\nissue: 5\n---\n\n# No tasks\n"
+    assert parse_plan_tasks(content) == PlanTasks(complete=0, total=0)
+
+def test_parse_plan_tasks_excludes_frontmatter():
+    content = "---\nchecks:\n  - item: x\n    done: false\n---\n\n- [x] Real task\n"
+    assert parse_plan_tasks(content) == PlanTasks(complete=1, total=1)

--- a/cli/tests/test_state.py
+++ b/cli/tests/test_state.py
@@ -1,0 +1,87 @@
+from hexis.state import State, determine_state
+
+
+def _write_spec(path, issue, checks, depends_on=None):
+    checks_yaml = "\n".join(
+        f"  - item: {c['item']}\n    done: {'true' if c['done'] else 'false'}"
+        for c in checks
+    )
+    dep_yaml = f"depends_on: {depends_on}\n" if depends_on else ""
+    path.write_text(
+        f"---\nissue: {issue}\n{dep_yaml}checks:\n{checks_yaml}\n---\n\n# Spec\n"
+    )
+
+
+def _write_plan(path, issue, tasks):
+    task_lines = "\n".join(
+        f"- [{'x' if done else ' '}] Task {i + 1}" for i, done in enumerate(tasks)
+    )
+    path.write_text(f"---\nissue: {issue}\n---\n\n{task_lines}\n")
+
+
+def test_needs_spec_missing_dir(tmp_path):
+    result = determine_state(tmp_path, 99)
+    assert result.state == State.NEEDS_SPEC
+
+
+def test_needs_spec_no_file(tmp_path):
+    (tmp_path / "docs" / "specs").mkdir(parents=True)
+    result = determine_state(tmp_path, 99)
+    assert result.state == State.NEEDS_SPEC
+    assert result.issue == 99
+    assert len(result.blocking) == 1
+
+
+def test_needs_plan(tmp_path):
+    specs_dir = tmp_path / "docs" / "specs"
+    specs_dir.mkdir(parents=True)
+    (tmp_path / "docs" / "plans").mkdir(parents=True)
+    _write_spec(specs_dir / "spec.md", 5, [{"item": "A", "done": False}])
+    result = determine_state(tmp_path, 5)
+    assert result.state == State.NEEDS_PLAN
+    assert len(result.blocking) == 1
+
+
+def test_in_progress(tmp_path):
+    specs_dir = tmp_path / "docs" / "specs"
+    plans_dir = tmp_path / "docs" / "plans"
+    specs_dir.mkdir(parents=True)
+    plans_dir.mkdir(parents=True)
+    _write_spec(specs_dir / "spec.md", 5, [{"item": "A", "done": False}])
+    _write_plan(plans_dir / "plan.md", 5, [True, False])
+    result = determine_state(tmp_path, 5)
+    assert result.state == State.IN_PROGRESS
+    assert result.plan_tasks is not None
+    assert result.plan_tasks.complete == 1
+    assert result.plan_tasks.total == 2
+
+
+def test_needs_verify(tmp_path):
+    specs_dir = tmp_path / "docs" / "specs"
+    plans_dir = tmp_path / "docs" / "plans"
+    specs_dir.mkdir(parents=True)
+    plans_dir.mkdir(parents=True)
+    _write_spec(specs_dir / "spec.md", 5, [{"item": "A", "done": False}])
+    _write_plan(plans_dir / "plan.md", 5, [True, True])
+    result = determine_state(tmp_path, 5)
+    assert result.state == State.NEEDS_VERIFY
+
+
+def test_done(tmp_path):
+    specs_dir = tmp_path / "docs" / "specs"
+    plans_dir = tmp_path / "docs" / "plans"
+    specs_dir.mkdir(parents=True)
+    plans_dir.mkdir(parents=True)
+    _write_spec(specs_dir / "spec.md", 5, [{"item": "A", "done": True}])
+    _write_plan(plans_dir / "plan.md", 5, [True])
+    result = determine_state(tmp_path, 5)
+    assert result.state == State.DONE
+
+
+def test_depends_on_surfaced(tmp_path):
+    specs_dir = tmp_path / "docs" / "specs"
+    specs_dir.mkdir(parents=True)
+    (tmp_path / "docs" / "plans").mkdir(parents=True)
+    _write_spec(specs_dir / "spec.md", 5, [{"item": "A", "done": False}], depends_on=[22])
+    result = determine_state(tmp_path, 5)
+    assert result.depends_on == [22]

--- a/cli/uv.lock
+++ b/cli/uv.lock
@@ -1,0 +1,220 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "hexis"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "pyyaml" },
+    { name = "typer" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
+    { name = "typer", extras = ["all"], specifier = ">=0.9.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7b/27/ede8cec7596e0041ba7e7b80b47d132562f56ff454313a16f6084e555c9f/typer-0.25.0.tar.gz", hash = "sha256:123eaf9f19bb40fd268310e12a542c0c6b4fab9c98d9d23342a01ff95e3ce930", size = 120150, upload-time = "2026-04-26T08:46:14.767Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/72/193d4e586ec5a4db834a36bbeb47641a62f951f114ffd0fe5b1b46e8d56f/typer-0.25.0-py3-none-any.whl", hash = "sha256:ac01b48823d3db9a83c9e164338057eadbb1c9957a2a6b4eeb486669c560b5dc", size = 55993, upload-time = "2026-04-26T08:46:15.889Z" },
+]

--- a/docs/plans/2026-04-29-hexis-cli-tool.md
+++ b/docs/plans/2026-04-29-hexis-cli-tool.md
@@ -43,13 +43,13 @@ linked_spec: docs/specs/2026-04-08-hexis-cli-tool-design.md
 - Create: `cli/tests/test_state.py`
 - Create: `cli/tests/test_cli.py`
 
-- [ ] **Step 1: Create directory structure**
+- [x] **Step 1: Create directory structure**
 
 ```bash
 mkdir -p cli/src/hexis cli/tests
 ```
 
-- [ ] **Step 2: Write `cli/pyproject.toml`**
+- [x] **Step 2: Write `cli/pyproject.toml`**
 
 ```toml
 [build-system]
@@ -78,7 +78,7 @@ packages = ["src/hexis"]
 testpaths = ["tests"]
 ```
 
-- [ ] **Step 3: Write skeleton source files**
+- [x] **Step 3: Write skeleton source files**
 
 `cli/src/hexis/__init__.py` — empty file.
 
@@ -110,7 +110,7 @@ app.add_typer(status_app, name="status")
 
 `cli/tests/test_parser.py`, `cli/tests/test_state.py`, `cli/tests/test_cli.py` — empty files.
 
-- [ ] **Step 4: Verify install**
+- [x] **Step 4: Verify install**
 
 ```bash
 cd cli && uv pip install -e ".[dev]" --quiet && python -c "import hexis; print('OK')"
@@ -118,7 +118,7 @@ cd cli && uv pip install -e ".[dev]" --quiet && python -c "import hexis; print('
 
 Expected: `OK`
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add cli/
@@ -133,7 +133,7 @@ git commit -m "feat: scaffold hexis CLI package (#22)"
 - Modify: `cli/src/hexis/parser.py`
 - Modify: `cli/tests/test_parser.py`
 
-- [ ] **Step 1: Write failing tests**
+- [x] **Step 1: Write failing tests**
 
 ```python
 # cli/tests/test_parser.py
@@ -156,7 +156,7 @@ def test_parse_frontmatter_incomplete_delimiter():
     assert parse_frontmatter("---\nissue: 5\n") == {}
 ```
 
-- [ ] **Step 2: Confirm failure**
+- [x] **Step 2: Confirm failure**
 
 ```bash
 cd cli && uv run pytest tests/test_parser.py -x
@@ -164,7 +164,7 @@ cd cli && uv run pytest tests/test_parser.py -x
 
 Expected: FAIL — `ImportError` or `AttributeError`
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 ```python
 # cli/src/hexis/parser.py — add after imports
@@ -177,7 +177,7 @@ def parse_frontmatter(content: str) -> dict:
     return yaml.safe_load(content[4:end]) or {}
 ```
 
-- [ ] **Step 4: Confirm pass**
+- [x] **Step 4: Confirm pass**
 
 ```bash
 cd cli && uv run pytest tests/test_parser.py -x
@@ -185,7 +185,7 @@ cd cli && uv run pytest tests/test_parser.py -x
 
 Expected: 4 passed
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add cli/src/hexis/parser.py cli/tests/test_parser.py
@@ -200,7 +200,7 @@ git commit -m "feat(cli): implement parse_frontmatter (#22)"
 - Modify: `cli/src/hexis/parser.py`
 - Modify: `cli/tests/test_parser.py`
 
-- [ ] **Step 1: Write failing tests**
+- [x] **Step 1: Write failing tests**
 
 ```python
 # cli/tests/test_parser.py — append
@@ -249,7 +249,7 @@ def test_find_plan_file_missing_dir(tmp_path):
     assert find_plan_file(tmp_path, 5) is None
 ```
 
-- [ ] **Step 2: Confirm failure**
+- [x] **Step 2: Confirm failure**
 
 ```bash
 cd cli && uv run pytest tests/test_parser.py::test_find_spec_file_found -x
@@ -257,7 +257,7 @@ cd cli && uv run pytest tests/test_parser.py::test_find_spec_file_found -x
 
 Expected: FAIL — `ImportError`
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 ```python
 # cli/src/hexis/parser.py — append
@@ -292,7 +292,7 @@ def find_plan_file(root: Path, issue: int) -> Path | None:
     return matches[0] if matches else None
 ```
 
-- [ ] **Step 4: Confirm pass**
+- [x] **Step 4: Confirm pass**
 
 ```bash
 cd cli && uv run pytest tests/test_parser.py -x
@@ -300,7 +300,7 @@ cd cli && uv run pytest tests/test_parser.py -x
 
 Expected: all passed
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add cli/src/hexis/parser.py cli/tests/test_parser.py
@@ -315,7 +315,7 @@ git commit -m "feat(cli): implement find_spec_file and find_plan_file (#22)"
 - Modify: `cli/src/hexis/parser.py`
 - Modify: `cli/tests/test_parser.py`
 
-- [ ] **Step 1: Write failing tests**
+- [x] **Step 1: Write failing tests**
 
 ```python
 # cli/tests/test_parser.py — append
@@ -353,7 +353,7 @@ def test_parse_depends_on_null():
     assert parse_depends_on({"depends_on": None}) == []
 ```
 
-- [ ] **Step 2: Confirm failure**
+- [x] **Step 2: Confirm failure**
 
 ```bash
 cd cli && uv run pytest tests/test_parser.py::test_parse_checks_mixed -x
@@ -361,7 +361,7 @@ cd cli && uv run pytest tests/test_parser.py::test_parse_checks_mixed -x
 
 Expected: FAIL — `ImportError`
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 ```python
 # cli/src/hexis/parser.py — insert after imports, before parse_frontmatter
@@ -386,7 +386,7 @@ def parse_depends_on(fm: dict) -> list[int]:
     return list(fm.get("depends_on") or [])
 ```
 
-- [ ] **Step 4: Confirm pass**
+- [x] **Step 4: Confirm pass**
 
 ```bash
 cd cli && uv run pytest tests/test_parser.py -x
@@ -394,7 +394,7 @@ cd cli && uv run pytest tests/test_parser.py -x
 
 Expected: all passed
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add cli/src/hexis/parser.py cli/tests/test_parser.py
@@ -409,7 +409,7 @@ git commit -m "feat(cli): implement parse_checks and parse_depends_on (#22)"
 - Modify: `cli/src/hexis/parser.py`
 - Modify: `cli/tests/test_parser.py`
 
-- [ ] **Step 1: Write failing tests**
+- [x] **Step 1: Write failing tests**
 
 ```python
 # cli/tests/test_parser.py — append
@@ -432,7 +432,7 @@ def test_parse_plan_tasks_excludes_frontmatter():
     assert parse_plan_tasks(content) == PlanTasks(complete=1, total=1)
 ```
 
-- [ ] **Step 2: Confirm failure**
+- [x] **Step 2: Confirm failure**
 
 ```bash
 cd cli && uv run pytest tests/test_parser.py::test_parse_plan_tasks_mixed -x
@@ -440,7 +440,7 @@ cd cli && uv run pytest tests/test_parser.py::test_parse_plan_tasks_mixed -x
 
 Expected: FAIL — `ImportError`
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 ```python
 # cli/src/hexis/parser.py — insert dataclass before parse_frontmatter, add function at end
@@ -465,7 +465,7 @@ def parse_plan_tasks(content: str) -> PlanTasks:
     return PlanTasks(complete=checked, total=checked + unchecked)
 ```
 
-- [ ] **Step 4: Confirm pass**
+- [x] **Step 4: Confirm pass**
 
 ```bash
 cd cli && uv run pytest tests/test_parser.py -x
@@ -473,7 +473,7 @@ cd cli && uv run pytest tests/test_parser.py -x
 
 Expected: all passed
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add cli/src/hexis/parser.py cli/tests/test_parser.py
@@ -488,7 +488,7 @@ git commit -m "feat(cli): implement parse_plan_tasks (#22)"
 - Modify: `cli/src/hexis/state.py`
 - Modify: `cli/tests/test_state.py`
 
-- [ ] **Step 1: Write failing tests**
+- [x] **Step 1: Write failing tests**
 
 ```python
 # cli/tests/test_state.py
@@ -572,7 +572,7 @@ def test_depends_on_surfaced(tmp_path):
     assert result.depends_on == [22]
 ```
 
-- [ ] **Step 2: Confirm failure**
+- [x] **Step 2: Confirm failure**
 
 ```bash
 cd cli && uv run pytest tests/test_state.py -x
@@ -580,7 +580,7 @@ cd cli && uv run pytest tests/test_state.py -x
 
 Expected: FAIL — `ImportError`
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 ```python
 # cli/src/hexis/state.py — full content
@@ -667,7 +667,7 @@ def determine_state(root: Path, issue: int) -> StateResult:
     )
 ```
 
-- [ ] **Step 4: Confirm pass**
+- [x] **Step 4: Confirm pass**
 
 ```bash
 cd cli && uv run pytest tests/test_state.py -x
@@ -675,7 +675,7 @@ cd cli && uv run pytest tests/test_state.py -x
 
 Expected: all passed
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add cli/src/hexis/state.py cli/tests/test_state.py
@@ -690,7 +690,7 @@ git commit -m "feat(cli): implement determine_state (#22)"
 - Modify: `cli/src/hexis/cli.py`
 - Modify: `cli/tests/test_cli.py`
 
-- [ ] **Step 1: Write failing tests**
+- [x] **Step 1: Write failing tests**
 
 ```python
 # cli/tests/test_cli.py
@@ -765,7 +765,7 @@ def test_status_read_missing_docs_graceful(tmp_path):
     assert "STATE: NEEDS_SPEC" in result.output
 ```
 
-- [ ] **Step 2: Confirm failure**
+- [x] **Step 2: Confirm failure**
 
 ```bash
 cd cli && uv run pytest tests/test_cli.py::test_status_read_needs_spec_plain -x
@@ -773,7 +773,7 @@ cd cli && uv run pytest tests/test_cli.py::test_status_read_needs_spec_plain -x
 
 Expected: FAIL — command not found or no such command
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 ```python
 # cli/src/hexis/cli.py — full content
@@ -849,7 +849,7 @@ def status_read(
         _render_plain(result)
 ```
 
-- [ ] **Step 4: Confirm pass**
+- [x] **Step 4: Confirm pass**
 
 ```bash
 cd cli && uv run pytest tests/test_cli.py -x -k "read"
@@ -857,7 +857,7 @@ cd cli && uv run pytest tests/test_cli.py -x -k "read"
 
 Expected: all `read` tests passed
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add cli/src/hexis/cli.py cli/tests/test_cli.py
@@ -873,7 +873,7 @@ git commit -m "feat(cli): implement status read command (#22)"
 - Modify: `cli/src/hexis/cli.py` (add `status update` command)
 - Modify: `cli/tests/test_cli.py`
 
-- [ ] **Step 1: Write failing tests**
+- [x] **Step 1: Write failing tests**
 
 ```python
 # cli/tests/test_cli.py — append
@@ -944,7 +944,7 @@ def test_status_update_no_spec_exits_1(tmp_path):
     assert result.exit_code == 1
 ```
 
-- [ ] **Step 2: Confirm failure**
+- [x] **Step 2: Confirm failure**
 
 ```bash
 cd cli && uv run pytest tests/test_cli.py::test_status_update_sets_checked -x
@@ -952,7 +952,7 @@ cd cli && uv run pytest tests/test_cli.py::test_status_update_sets_checked -x
 
 Expected: FAIL — no such command `update`
 
-- [ ] **Step 3: Implement `write_checks` in `parser.py`**
+- [x] **Step 3: Implement `write_checks` in `parser.py`**
 
 ```python
 # cli/src/hexis/parser.py — add imports at top and function at end
@@ -976,7 +976,7 @@ def write_checks(path: Path, new_checks: list[dict]) -> None:
     os.replace(tmp, path)
 ```
 
-- [ ] **Step 4: Implement `status update` in `cli.py`**
+- [x] **Step 4: Implement `status update` in `cli.py`**
 
 ```python
 # cli/src/hexis/cli.py — add import and command
@@ -1036,7 +1036,7 @@ def status_update(
     _render_plain(result)
 ```
 
-- [ ] **Step 5: Confirm pass**
+- [x] **Step 5: Confirm pass**
 
 ```bash
 cd cli && uv run pytest tests/test_cli.py -x
@@ -1044,7 +1044,7 @@ cd cli && uv run pytest tests/test_cli.py -x
 
 Expected: all passed
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add cli/src/hexis/parser.py cli/src/hexis/cli.py cli/tests/test_cli.py
@@ -1058,7 +1058,7 @@ git commit -m "feat(cli): implement status update command (#22)"
 **Files:**
 - No code changes — install and smoke-test only
 
-- [ ] **Step 1: Run full test suite**
+- [x] **Step 1: Run full test suite**
 
 ```bash
 cd cli && uv run pytest
@@ -1066,7 +1066,7 @@ cd cli && uv run pytest
 
 Expected: all tests pass, 0 failures
 
-- [ ] **Step 2: Install via `uv tool install`**
+- [x] **Step 2: Install via `uv tool install`**
 
 ```bash
 uv tool install ./cli
@@ -1074,7 +1074,7 @@ uv tool install ./cli
 
 Expected: exits 0, no errors
 
-- [ ] **Step 3: Smoke-test installed binary**
+- [x] **Step 3: Smoke-test installed binary**
 
 ```bash
 hexis --help
@@ -1084,7 +1084,7 @@ hexis status update --help
 
 Expected: each shows command help without errors.
 
-- [ ] **Step 4: Verify NEEDS_SPEC output with real repo**
+- [x] **Step 4: Verify NEEDS_SPEC output with real repo**
 
 ```bash
 hexis status read 999
@@ -1100,7 +1100,7 @@ BLOCKING:
   No spec file found in docs/specs/ for issue #999
 ```
 
-- [ ] **Step 5: Verify real issue lookup**
+- [x] **Step 5: Verify real issue lookup**
 
 ```bash
 hexis status read 22
@@ -1108,7 +1108,7 @@ hexis status read 22
 
 Expected: first line is `STATE: NEEDS_VERIFY` or `STATE: IN_PROGRESS` (since spec and plan now exist for #22).
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add -A

--- a/docs/plans/2026-04-29-hexis-cli-tool.md
+++ b/docs/plans/2026-04-29-hexis-cli-tool.md
@@ -1,0 +1,1116 @@
+---
+issue: 22
+status: READY_TO_IMPLEMENT
+linked_spec: docs/specs/2026-04-08-hexis-cli-tool-design.md
+---
+
+# hexis CLI Tool — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `hexis:implement` to execute task by task. For TDD tasks, follow `hexis:testing-principles`. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a stateless Python CLI (`hexis`) that reads `docs/specs/` and `docs/plans/` to report workflow state and update spec acceptance-criteria completion.
+
+**Architecture:** Three modules with a clean dependency chain — `parser.py` (file I/O and content parsing) ← `state.py` (state machine) ← `cli.py` (Typer commands). All reads are fresh per invocation; writes are atomic via `os.replace`. YAML frontmatter is parsed with PyYAML.
+
+**Tech Stack:** Python ≥ 3.11, typer[all], pyyaml, pytest, hatchling (build), uv (install/run)
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `cli/pyproject.toml` | Package metadata, entry point, dependencies |
+| `cli/src/hexis/__init__.py` | Package marker (empty) |
+| `cli/src/hexis/parser.py` | `MultipleMatchError`, `Check`, `PlanTasks`; frontmatter parsing, file discovery, `write_checks` |
+| `cli/src/hexis/state.py` | `State`, `StateResult`, `determine_state` |
+| `cli/src/hexis/cli.py` | Typer app, `status read`, `status update` commands |
+| `cli/tests/test_parser.py` | Tests for all `parser.py` functions |
+| `cli/tests/test_state.py` | Tests for `determine_state` covering all 5 states |
+| `cli/tests/test_cli.py` | End-to-end CLI tests via `typer.testing.CliRunner` |
+
+---
+
+### Task 1: Project scaffolding [No TDD — pure configuration]
+
+**Files:**
+- Create: `cli/pyproject.toml`
+- Create: `cli/src/hexis/__init__.py`
+- Create: `cli/src/hexis/parser.py`
+- Create: `cli/src/hexis/state.py`
+- Create: `cli/src/hexis/cli.py`
+- Create: `cli/tests/test_parser.py`
+- Create: `cli/tests/test_state.py`
+- Create: `cli/tests/test_cli.py`
+
+- [ ] **Step 1: Create directory structure**
+
+```bash
+mkdir -p cli/src/hexis cli/tests
+```
+
+- [ ] **Step 2: Write `cli/pyproject.toml`**
+
+```toml
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "hexis"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+    "typer[all]>=0.9.0",
+    "pyyaml>=6.0",
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=7.0"]
+
+[project.scripts]
+hexis = "hexis.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/hexis"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+```
+
+- [ ] **Step 3: Write skeleton source files**
+
+`cli/src/hexis/__init__.py` — empty file.
+
+`cli/src/hexis/parser.py`:
+```python
+from __future__ import annotations
+from dataclasses import dataclass
+from pathlib import Path
+import yaml
+```
+
+`cli/src/hexis/state.py`:
+```python
+from __future__ import annotations
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+```
+
+`cli/src/hexis/cli.py`:
+```python
+from __future__ import annotations
+import typer
+
+app = typer.Typer()
+status_app = typer.Typer()
+app.add_typer(status_app, name="status")
+```
+
+`cli/tests/test_parser.py`, `cli/tests/test_state.py`, `cli/tests/test_cli.py` — empty files.
+
+- [ ] **Step 4: Verify install**
+
+```bash
+cd cli && uv pip install -e ".[dev]" --quiet && python -c "import hexis; print('OK')"
+```
+
+Expected: `OK`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/
+git commit -m "feat: scaffold hexis CLI package (#22)"
+```
+
+---
+
+### Task 2: `parse_frontmatter` [TDD]
+
+**Files:**
+- Modify: `cli/src/hexis/parser.py`
+- Modify: `cli/tests/test_parser.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+# cli/tests/test_parser.py
+from hexis.parser import parse_frontmatter
+
+def test_parse_frontmatter_valid():
+    content = "---\nissue: 5\nstatus: READY_TO_PLAN\n---\n\n# Title\n"
+    fm = parse_frontmatter(content)
+    assert fm == {"issue": 5, "status": "READY_TO_PLAN"}
+
+def test_parse_frontmatter_with_checks():
+    content = "---\nchecks:\n  - item: criterion\n    done: false\n---\n\n# Title\n"
+    fm = parse_frontmatter(content)
+    assert fm["checks"] == [{"item": "criterion", "done": False}]
+
+def test_parse_frontmatter_no_frontmatter():
+    assert parse_frontmatter("# Just a title\n") == {}
+
+def test_parse_frontmatter_incomplete_delimiter():
+    assert parse_frontmatter("---\nissue: 5\n") == {}
+```
+
+- [ ] **Step 2: Confirm failure**
+
+```bash
+cd cli && uv run pytest tests/test_parser.py -x
+```
+
+Expected: FAIL — `ImportError` or `AttributeError`
+
+- [ ] **Step 3: Implement**
+
+```python
+# cli/src/hexis/parser.py — add after imports
+def parse_frontmatter(content: str) -> dict:
+    if not content.startswith("---\n"):
+        return {}
+    end = content.find("\n---\n", 4)
+    if end == -1:
+        return {}
+    return yaml.safe_load(content[4:end]) or {}
+```
+
+- [ ] **Step 4: Confirm pass**
+
+```bash
+cd cli && uv run pytest tests/test_parser.py -x
+```
+
+Expected: 4 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/src/hexis/parser.py cli/tests/test_parser.py
+git commit -m "feat(cli): implement parse_frontmatter (#22)"
+```
+
+---
+
+### Task 3: File discovery — `find_spec_file`, `find_plan_file` [TDD]
+
+**Files:**
+- Modify: `cli/src/hexis/parser.py`
+- Modify: `cli/tests/test_parser.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+# cli/tests/test_parser.py — append
+import pytest
+from hexis.parser import find_spec_file, find_plan_file, MultipleMatchError
+
+def test_find_spec_file_found(tmp_path):
+    specs_dir = tmp_path / "docs" / "specs"
+    specs_dir.mkdir(parents=True)
+    (specs_dir / "2026-01-01-foo-design.md").write_text(
+        "---\nissue: 5\nstatus: READY_TO_PLAN\n---\n\n# Foo\n"
+    )
+    result = find_spec_file(tmp_path, 5)
+    assert result is not None
+    assert result.name == "2026-01-01-foo-design.md"
+
+def test_find_spec_file_not_found(tmp_path):
+    (tmp_path / "docs" / "specs").mkdir(parents=True)
+    assert find_spec_file(tmp_path, 99) is None
+
+def test_find_spec_file_missing_dir(tmp_path):
+    assert find_spec_file(tmp_path, 5) is None
+
+def test_find_spec_file_multiple_raises(tmp_path):
+    specs_dir = tmp_path / "docs" / "specs"
+    specs_dir.mkdir(parents=True)
+    (specs_dir / "a.md").write_text("---\nissue: 5\n---\n\n# A\n")
+    (specs_dir / "b.md").write_text("---\nissue: 5\n---\n\n# B\n")
+    with pytest.raises(MultipleMatchError):
+        find_spec_file(tmp_path, 5)
+
+def test_find_plan_file_found(tmp_path):
+    plans_dir = tmp_path / "docs" / "plans"
+    plans_dir.mkdir(parents=True)
+    (plans_dir / "2026-01-01-foo.md").write_text(
+        "---\nissue: 5\nstatus: READY_TO_IMPLEMENT\n---\n\n# Foo Plan\n"
+    )
+    result = find_plan_file(tmp_path, 5)
+    assert result is not None
+
+def test_find_plan_file_not_found(tmp_path):
+    (tmp_path / "docs" / "plans").mkdir(parents=True)
+    assert find_plan_file(tmp_path, 99) is None
+
+def test_find_plan_file_missing_dir(tmp_path):
+    assert find_plan_file(tmp_path, 5) is None
+```
+
+- [ ] **Step 2: Confirm failure**
+
+```bash
+cd cli && uv run pytest tests/test_parser.py::test_find_spec_file_found -x
+```
+
+Expected: FAIL — `ImportError`
+
+- [ ] **Step 3: Implement**
+
+```python
+# cli/src/hexis/parser.py — append
+
+class MultipleMatchError(Exception):
+    pass
+
+def find_spec_file(root: Path, issue: int) -> Path | None:
+    specs_dir = root / "docs" / "specs"
+    if not specs_dir.is_dir():
+        return None
+    matches = [
+        p for p in specs_dir.glob("*.md")
+        if parse_frontmatter(p.read_text()).get("issue") == issue
+    ]
+    if len(matches) > 1:
+        names = ", ".join(p.name for p in sorted(matches))
+        raise MultipleMatchError(f"Multiple spec files match issue #{issue}: {names}")
+    return matches[0] if matches else None
+
+def find_plan_file(root: Path, issue: int) -> Path | None:
+    plans_dir = root / "docs" / "plans"
+    if not plans_dir.is_dir():
+        return None
+    matches = [
+        p for p in plans_dir.glob("*.md")
+        if parse_frontmatter(p.read_text()).get("issue") == issue
+    ]
+    if len(matches) > 1:
+        names = ", ".join(p.name for p in sorted(matches))
+        raise MultipleMatchError(f"Multiple plan files match issue #{issue}: {names}")
+    return matches[0] if matches else None
+```
+
+- [ ] **Step 4: Confirm pass**
+
+```bash
+cd cli && uv run pytest tests/test_parser.py -x
+```
+
+Expected: all passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/src/hexis/parser.py cli/tests/test_parser.py
+git commit -m "feat(cli): implement find_spec_file and find_plan_file (#22)"
+```
+
+---
+
+### Task 4: Spec content parsing — `parse_checks`, `parse_depends_on` [TDD]
+
+**Files:**
+- Modify: `cli/src/hexis/parser.py`
+- Modify: `cli/tests/test_parser.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+# cli/tests/test_parser.py — append
+from hexis.parser import parse_checks, parse_depends_on, Check
+
+def test_parse_checks_mixed():
+    fm = {
+        "checks": [
+            {"item": "First criterion", "done": True},
+            {"item": "Second criterion", "done": False},
+        ]
+    }
+    result = parse_checks(fm)
+    assert result == [
+        Check(index=0, text="First criterion", checked=True),
+        Check(index=1, text="Second criterion", checked=False),
+    ]
+
+def test_parse_checks_empty_fm():
+    assert parse_checks({}) == []
+
+def test_parse_checks_preserves_order():
+    fm = {"checks": [{"item": "Z", "done": False}, {"item": "A", "done": True}]}
+    result = parse_checks(fm)
+    assert result[0].text == "Z"
+    assert result[1].text == "A"
+
+def test_parse_depends_on_list():
+    assert parse_depends_on({"depends_on": [22, 23]}) == [22, 23]
+
+def test_parse_depends_on_absent():
+    assert parse_depends_on({}) == []
+
+def test_parse_depends_on_null():
+    assert parse_depends_on({"depends_on": None}) == []
+```
+
+- [ ] **Step 2: Confirm failure**
+
+```bash
+cd cli && uv run pytest tests/test_parser.py::test_parse_checks_mixed -x
+```
+
+Expected: FAIL — `ImportError`
+
+- [ ] **Step 3: Implement**
+
+```python
+# cli/src/hexis/parser.py — insert after imports, before parse_frontmatter
+
+@dataclass
+class Check:
+    index: int
+    text: str
+    checked: bool
+
+# ... existing functions ...
+
+# append at end of parser.py
+
+def parse_checks(fm: dict) -> list[Check]:
+    return [
+        Check(index=i, text=c["item"], checked=bool(c["done"]))
+        for i, c in enumerate(fm.get("checks") or [])
+    ]
+
+def parse_depends_on(fm: dict) -> list[int]:
+    return list(fm.get("depends_on") or [])
+```
+
+- [ ] **Step 4: Confirm pass**
+
+```bash
+cd cli && uv run pytest tests/test_parser.py -x
+```
+
+Expected: all passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/src/hexis/parser.py cli/tests/test_parser.py
+git commit -m "feat(cli): implement parse_checks and parse_depends_on (#22)"
+```
+
+---
+
+### Task 5: Plan task parsing — `parse_plan_tasks` [TDD]
+
+**Files:**
+- Modify: `cli/src/hexis/parser.py`
+- Modify: `cli/tests/test_parser.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+# cli/tests/test_parser.py — append
+from hexis.parser import parse_plan_tasks, PlanTasks
+
+def test_parse_plan_tasks_mixed():
+    content = "---\nissue: 5\n---\n\n- [x] Task one\n- [ ] Task two\n- [x] Task three\n"
+    assert parse_plan_tasks(content) == PlanTasks(complete=2, total=3)
+
+def test_parse_plan_tasks_all_done():
+    content = "---\nissue: 5\n---\n\n- [x] Task one\n- [x] Task two\n"
+    assert parse_plan_tasks(content) == PlanTasks(complete=2, total=2)
+
+def test_parse_plan_tasks_none():
+    content = "---\nissue: 5\n---\n\n# No tasks\n"
+    assert parse_plan_tasks(content) == PlanTasks(complete=0, total=0)
+
+def test_parse_plan_tasks_excludes_frontmatter():
+    content = "---\nchecks:\n  - item: x\n    done: false\n---\n\n- [x] Real task\n"
+    assert parse_plan_tasks(content) == PlanTasks(complete=1, total=1)
+```
+
+- [ ] **Step 2: Confirm failure**
+
+```bash
+cd cli && uv run pytest tests/test_parser.py::test_parse_plan_tasks_mixed -x
+```
+
+Expected: FAIL — `ImportError`
+
+- [ ] **Step 3: Implement**
+
+```python
+# cli/src/hexis/parser.py — insert dataclass before parse_frontmatter, add function at end
+
+import re  # add to top-level imports
+
+@dataclass
+class PlanTasks:
+    complete: int
+    total: int
+
+# ... at end of file:
+
+def parse_plan_tasks(content: str) -> PlanTasks:
+    body = content
+    if content.startswith("---\n"):
+        end = content.find("\n---\n", 4)
+        if end != -1:
+            body = content[end + 5:]
+    checked = len(re.findall(r"^- \[x\]", body, re.MULTILINE))
+    unchecked = len(re.findall(r"^- \[ \]", body, re.MULTILINE))
+    return PlanTasks(complete=checked, total=checked + unchecked)
+```
+
+- [ ] **Step 4: Confirm pass**
+
+```bash
+cd cli && uv run pytest tests/test_parser.py -x
+```
+
+Expected: all passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/src/hexis/parser.py cli/tests/test_parser.py
+git commit -m "feat(cli): implement parse_plan_tasks (#22)"
+```
+
+---
+
+### Task 6: State determination — `determine_state` [TDD]
+
+**Files:**
+- Modify: `cli/src/hexis/state.py`
+- Modify: `cli/tests/test_state.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+# cli/tests/test_state.py
+from hexis.state import State, determine_state
+
+def _write_spec(path, issue, checks, depends_on=None):
+    checks_yaml = "\n".join(
+        f"  - item: {c['item']}\n    done: {'true' if c['done'] else 'false'}"
+        for c in checks
+    )
+    dep_yaml = f"depends_on: {depends_on}\n" if depends_on else ""
+    path.write_text(
+        f"---\nissue: {issue}\n{dep_yaml}checks:\n{checks_yaml}\n---\n\n# Spec\n"
+    )
+
+def _write_plan(path, issue, tasks):
+    task_lines = "\n".join(
+        f"- [{'x' if done else ' '}] Task {i+1}" for i, done in enumerate(tasks)
+    )
+    path.write_text(f"---\nissue: {issue}\n---\n\n{task_lines}\n")
+
+def test_needs_spec_missing_dir(tmp_path):
+    result = determine_state(tmp_path, 99)
+    assert result.state == State.NEEDS_SPEC
+
+def test_needs_spec_no_file(tmp_path):
+    (tmp_path / "docs" / "specs").mkdir(parents=True)
+    result = determine_state(tmp_path, 99)
+    assert result.state == State.NEEDS_SPEC
+    assert result.issue == 99
+    assert len(result.blocking) == 1
+
+def test_needs_plan(tmp_path):
+    specs_dir = tmp_path / "docs" / "specs"
+    specs_dir.mkdir(parents=True)
+    (tmp_path / "docs" / "plans").mkdir(parents=True)
+    _write_spec(specs_dir / "spec.md", 5, [{"item": "A", "done": False}])
+    result = determine_state(tmp_path, 5)
+    assert result.state == State.NEEDS_PLAN
+    assert len(result.blocking) == 1
+
+def test_in_progress(tmp_path):
+    specs_dir = tmp_path / "docs" / "specs"
+    plans_dir = tmp_path / "docs" / "plans"
+    specs_dir.mkdir(parents=True)
+    plans_dir.mkdir(parents=True)
+    _write_spec(specs_dir / "spec.md", 5, [{"item": "A", "done": False}])
+    _write_plan(plans_dir / "plan.md", 5, [True, False])
+    result = determine_state(tmp_path, 5)
+    assert result.state == State.IN_PROGRESS
+    assert result.plan_tasks is not None
+    assert result.plan_tasks.complete == 1
+    assert result.plan_tasks.total == 2
+
+def test_needs_verify(tmp_path):
+    specs_dir = tmp_path / "docs" / "specs"
+    plans_dir = tmp_path / "docs" / "plans"
+    specs_dir.mkdir(parents=True)
+    plans_dir.mkdir(parents=True)
+    _write_spec(specs_dir / "spec.md", 5, [{"item": "A", "done": False}])
+    _write_plan(plans_dir / "plan.md", 5, [True, True])
+    result = determine_state(tmp_path, 5)
+    assert result.state == State.NEEDS_VERIFY
+
+def test_done(tmp_path):
+    specs_dir = tmp_path / "docs" / "specs"
+    plans_dir = tmp_path / "docs" / "plans"
+    specs_dir.mkdir(parents=True)
+    plans_dir.mkdir(parents=True)
+    _write_spec(specs_dir / "spec.md", 5, [{"item": "A", "done": True}])
+    _write_plan(plans_dir / "plan.md", 5, [True])
+    result = determine_state(tmp_path, 5)
+    assert result.state == State.DONE
+
+def test_depends_on_surfaced(tmp_path):
+    specs_dir = tmp_path / "docs" / "specs"
+    specs_dir.mkdir(parents=True)
+    (tmp_path / "docs" / "plans").mkdir(parents=True)
+    _write_spec(specs_dir / "spec.md", 5, [{"item": "A", "done": False}], depends_on=[22])
+    result = determine_state(tmp_path, 5)
+    assert result.depends_on == [22]
+```
+
+- [ ] **Step 2: Confirm failure**
+
+```bash
+cd cli && uv run pytest tests/test_state.py -x
+```
+
+Expected: FAIL — `ImportError`
+
+- [ ] **Step 3: Implement**
+
+```python
+# cli/src/hexis/state.py — full content
+
+from __future__ import annotations
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+
+from hexis.parser import (
+    Check, PlanTasks, MultipleMatchError,
+    find_spec_file, find_plan_file,
+    parse_frontmatter, parse_checks, parse_depends_on, parse_plan_tasks,
+)
+
+
+class State(str, Enum):
+    NEEDS_SPEC = "NEEDS_SPEC"
+    NEEDS_PLAN = "NEEDS_PLAN"
+    IN_PROGRESS = "IN_PROGRESS"
+    NEEDS_VERIFY = "NEEDS_VERIFY"
+    DONE = "DONE"
+
+
+@dataclass
+class StateResult:
+    state: State
+    issue: int
+    depends_on: list[int] = field(default_factory=list)
+    plan_tasks: PlanTasks | None = None
+    checks: list[Check] = field(default_factory=list)
+    blocking: list[str] = field(default_factory=list)
+
+
+def determine_state(root: Path, issue: int) -> StateResult:
+    spec_path = find_spec_file(root, issue)
+    if spec_path is None:
+        return StateResult(
+            state=State.NEEDS_SPEC,
+            issue=issue,
+            blocking=[f"No spec file found in docs/specs/ for issue #{issue}"],
+        )
+
+    spec_fm = parse_frontmatter(spec_path.read_text())
+    checks = parse_checks(spec_fm)
+    depends_on = parse_depends_on(spec_fm)
+
+    plan_path = find_plan_file(root, issue)
+    if plan_path is None:
+        return StateResult(
+            state=State.NEEDS_PLAN,
+            issue=issue,
+            depends_on=depends_on,
+            checks=checks,
+            blocking=[f"No plan file found in docs/plans/ for issue #{issue}"],
+        )
+
+    plan_tasks = parse_plan_tasks(plan_path.read_text())
+
+    if plan_tasks.total > 0 and plan_tasks.complete < plan_tasks.total:
+        return StateResult(
+            state=State.IN_PROGRESS,
+            issue=issue,
+            depends_on=depends_on,
+            plan_tasks=plan_tasks,
+            checks=checks,
+        )
+
+    if any(not c.checked for c in checks):
+        return StateResult(
+            state=State.NEEDS_VERIFY,
+            issue=issue,
+            depends_on=depends_on,
+            plan_tasks=plan_tasks,
+            checks=checks,
+        )
+
+    return StateResult(
+        state=State.DONE,
+        issue=issue,
+        depends_on=depends_on,
+        plan_tasks=plan_tasks,
+        checks=checks,
+    )
+```
+
+- [ ] **Step 4: Confirm pass**
+
+```bash
+cd cli && uv run pytest tests/test_state.py -x
+```
+
+Expected: all passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/src/hexis/state.py cli/tests/test_state.py
+git commit -m "feat(cli): implement determine_state (#22)"
+```
+
+---
+
+### Task 7: `status read` command [TDD]
+
+**Files:**
+- Modify: `cli/src/hexis/cli.py`
+- Modify: `cli/tests/test_cli.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+# cli/tests/test_cli.py
+import json
+from typer.testing import CliRunner
+from hexis.cli import app
+
+runner = CliRunner()
+
+
+def _setup_needs_verify(tmp_path):
+    specs_dir = tmp_path / "docs" / "specs"
+    plans_dir = tmp_path / "docs" / "plans"
+    specs_dir.mkdir(parents=True)
+    plans_dir.mkdir(parents=True)
+    (specs_dir / "spec.md").write_text(
+        "---\nissue: 5\nchecks:\n  - item: A\n    done: false\n  - item: B\n    done: true\n---\n\n# Spec\n"
+    )
+    (plans_dir / "plan.md").write_text(
+        "---\nissue: 5\n---\n\n- [x] Step 1\n- [x] Step 2\n"
+    )
+
+
+def test_status_read_needs_spec_plain(tmp_path):
+    (tmp_path / "docs" / "specs").mkdir(parents=True)
+    result = runner.invoke(app, ["status", "read", "99", "--root", str(tmp_path)])
+    assert result.exit_code == 0
+    assert "STATE: NEEDS_SPEC" in result.output
+    assert "ISSUE: 99" in result.output
+    assert "DEPENDS ON: (none)" in result.output
+    assert "BLOCKING:" in result.output
+
+
+def test_status_read_needs_verify_plain(tmp_path):
+    _setup_needs_verify(tmp_path)
+    result = runner.invoke(app, ["status", "read", "5", "--root", str(tmp_path)])
+    assert result.exit_code == 0
+    assert "STATE: NEEDS_VERIFY" in result.output
+    assert "PLAN TASKS: 2/2 complete" in result.output
+    assert "CHECKS:" in result.output
+    assert "[ ] #0  A" in result.output
+    assert "[x] #1  B" in result.output
+
+
+def test_status_read_json_needs_spec(tmp_path):
+    (tmp_path / "docs" / "specs").mkdir(parents=True)
+    result = runner.invoke(app, ["status", "read", "99", "--json", "--root", str(tmp_path)])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["state"] == "NEEDS_SPEC"
+    assert data["issue"] == 99
+    assert data["depends_on"] == []
+    assert data["plan_tasks"] is None
+    assert data["checks"] == []
+    assert len(data["blocking"]) == 1
+
+
+def test_status_read_json_needs_verify(tmp_path):
+    _setup_needs_verify(tmp_path)
+    result = runner.invoke(app, ["status", "read", "5", "--json", "--root", str(tmp_path)])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["state"] == "NEEDS_VERIFY"
+    assert data["plan_tasks"] == {"complete": 2, "total": 2}
+    assert data["checks"][0] == {"index": 0, "text": "A", "checked": False}
+    assert data["checks"][1] == {"index": 1, "text": "B", "checked": True}
+
+
+def test_status_read_missing_docs_graceful(tmp_path):
+    result = runner.invoke(app, ["status", "read", "99", "--root", str(tmp_path)])
+    assert result.exit_code == 0
+    assert "STATE: NEEDS_SPEC" in result.output
+```
+
+- [ ] **Step 2: Confirm failure**
+
+```bash
+cd cli && uv run pytest tests/test_cli.py::test_status_read_needs_spec_plain -x
+```
+
+Expected: FAIL — command not found or no such command
+
+- [ ] **Step 3: Implement**
+
+```python
+# cli/src/hexis/cli.py — full content
+
+from __future__ import annotations
+import json as json_lib
+from pathlib import Path
+
+import typer
+
+from hexis.parser import MultipleMatchError
+from hexis.state import State, StateResult, determine_state
+
+app = typer.Typer()
+status_app = typer.Typer()
+app.add_typer(status_app, name="status")
+
+
+def _render_plain(result: StateResult) -> None:
+    typer.echo(f"STATE: {result.state.value}")
+    typer.echo(f"ISSUE: {result.issue}")
+    depends_str = ", ".join(f"#{n}" for n in result.depends_on) if result.depends_on else "(none)"
+    typer.echo(f"DEPENDS ON: {depends_str}")
+
+    if result.state in (State.NEEDS_SPEC, State.NEEDS_PLAN):
+        typer.echo("")
+        typer.echo("BLOCKING:")
+        for b in result.blocking:
+            typer.echo(f"  {b}")
+        return
+
+    if result.plan_tasks is not None:
+        typer.echo("")
+        typer.echo(f"PLAN TASKS: {result.plan_tasks.complete}/{result.plan_tasks.total} complete")
+
+    typer.echo("")
+    typer.echo("CHECKS:")
+    for c in result.checks:
+        mark = "x" if c.checked else " "
+        typer.echo(f"  [{mark}] #{c.index}  {c.text}")
+
+
+@status_app.command("read")
+def status_read(
+    issue: int,
+    json: bool = typer.Option(False, "--json"),
+    root: Path = typer.Option(Path("."), "--root"),
+) -> None:
+    root = root.resolve()
+    try:
+        result = determine_state(root, issue)
+    except MultipleMatchError as e:
+        typer.echo(str(e), err=True)
+        raise typer.Exit(2)
+
+    if json:
+        output = {
+            "state": result.state.value,
+            "issue": result.issue,
+            "depends_on": result.depends_on,
+            "plan_tasks": (
+                {"complete": result.plan_tasks.complete, "total": result.plan_tasks.total}
+                if result.plan_tasks is not None else None
+            ),
+            "checks": [
+                {"index": c.index, "text": c.text, "checked": c.checked}
+                for c in result.checks
+            ],
+            "blocking": result.blocking,
+        }
+        typer.echo(json_lib.dumps(output, indent=2))
+    else:
+        _render_plain(result)
+```
+
+- [ ] **Step 4: Confirm pass**
+
+```bash
+cd cli && uv run pytest tests/test_cli.py -x -k "read"
+```
+
+Expected: all `read` tests passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/src/hexis/cli.py cli/tests/test_cli.py
+git commit -m "feat(cli): implement status read command (#22)"
+```
+
+---
+
+### Task 8: `status update` command [TDD]
+
+**Files:**
+- Modify: `cli/src/hexis/parser.py` (add `write_checks`)
+- Modify: `cli/src/hexis/cli.py` (add `status update` command)
+- Modify: `cli/tests/test_cli.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+# cli/tests/test_cli.py — append
+from hexis.parser import parse_frontmatter
+
+
+def _setup_spec_with_plan(tmp_path, issue, checks_done):
+    specs_dir = tmp_path / "docs" / "specs"
+    plans_dir = tmp_path / "docs" / "plans"
+    specs_dir.mkdir(parents=True, exist_ok=True)
+    plans_dir.mkdir(parents=True, exist_ok=True)
+    checks_yaml = "\n".join(
+        f"  - item: Item {i}\n    done: {'true' if d else 'false'}"
+        for i, d in enumerate(checks_done)
+    )
+    spec_path = specs_dir / "spec.md"
+    spec_path.write_text(
+        f"---\nissue: {issue}\nchecks:\n{checks_yaml}\n---\n\n# Spec\n"
+    )
+    (plans_dir / "plan.md").write_text(
+        f"---\nissue: {issue}\n---\n\n- [x] Step 1\n"
+    )
+    return spec_path
+
+
+def test_status_update_sets_checked(tmp_path):
+    spec_path = _setup_spec_with_plan(tmp_path, 5, [False, False])
+    result = runner.invoke(
+        app, ["status", "update", "5", "--checked", "0", "--unchecked", "1", "--root", str(tmp_path)]
+    )
+    assert result.exit_code == 0
+    fm = parse_frontmatter(spec_path.read_text())
+    assert fm["checks"][0]["done"] is True
+    assert fm["checks"][1]["done"] is False
+    assert "STATE:" in result.output
+
+
+def test_status_update_all_checked_yields_done(tmp_path):
+    spec_path = _setup_spec_with_plan(tmp_path, 5, [False])
+    result = runner.invoke(
+        app, ["status", "update", "5", "--checked", "0", "--unchecked", "", "--root", str(tmp_path)]
+    )
+    assert result.exit_code == 0
+    assert "STATE: DONE" in result.output
+
+
+def test_status_update_incomplete_coverage_exits_1(tmp_path):
+    _setup_spec_with_plan(tmp_path, 5, [False, False])
+    result = runner.invoke(
+        app, ["status", "update", "5", "--checked", "0", "--unchecked", "", "--root", str(tmp_path)]
+    )
+    assert result.exit_code == 1
+
+
+def test_status_update_overlapping_indices_exits_1(tmp_path):
+    _setup_spec_with_plan(tmp_path, 5, [False, False])
+    result = runner.invoke(
+        app, ["status", "update", "5", "--checked", "0,1", "--unchecked", "0", "--root", str(tmp_path)]
+    )
+    assert result.exit_code == 1
+
+
+def test_status_update_no_spec_exits_1(tmp_path):
+    (tmp_path / "docs" / "specs").mkdir(parents=True)
+    result = runner.invoke(
+        app, ["status", "update", "99", "--checked", "", "--unchecked", "", "--root", str(tmp_path)]
+    )
+    assert result.exit_code == 1
+```
+
+- [ ] **Step 2: Confirm failure**
+
+```bash
+cd cli && uv run pytest tests/test_cli.py::test_status_update_sets_checked -x
+```
+
+Expected: FAIL — no such command `update`
+
+- [ ] **Step 3: Implement `write_checks` in `parser.py`**
+
+```python
+# cli/src/hexis/parser.py — add imports at top and function at end
+
+import os
+import tempfile
+
+def write_checks(path: Path, new_checks: list[dict]) -> None:
+    content = path.read_text()
+    end = content.find("\n---\n", 4)
+    fm = yaml.safe_load(content[4:end]) or {}
+    body = content[end + 5:]
+    fm["checks"] = new_checks
+    new_fm = yaml.dump(fm, default_flow_style=False, allow_unicode=True, sort_keys=False)
+    new_content = f"---\n{new_fm}---\n{body}"
+    with tempfile.NamedTemporaryFile(
+        mode="w", dir=path.parent, delete=False, suffix=".tmp", encoding="utf-8"
+    ) as f:
+        f.write(new_content)
+        tmp = f.name
+    os.replace(tmp, path)
+```
+
+- [ ] **Step 4: Implement `status update` in `cli.py`**
+
+```python
+# cli/src/hexis/cli.py — add import and command
+
+from hexis.parser import MultipleMatchError, find_spec_file, parse_frontmatter, write_checks
+
+# ... existing code ...
+
+@status_app.command("update")
+def status_update(
+    issue: int,
+    checked: str = typer.Option(..., "--checked"),
+    unchecked: str = typer.Option(..., "--unchecked"),
+    root: Path = typer.Option(Path("."), "--root"),
+) -> None:
+    root = root.resolve()
+
+    try:
+        checked_idx = [int(i.strip()) for i in checked.split(",") if i.strip()]
+        unchecked_idx = [int(i.strip()) for i in unchecked.split(",") if i.strip()]
+    except ValueError:
+        typer.echo("Error: indices must be integers", err=True)
+        raise typer.Exit(1)
+
+    all_idx = sorted(checked_idx + unchecked_idx)
+
+    try:
+        spec_path = find_spec_file(root, issue)
+    except MultipleMatchError as e:
+        typer.echo(str(e), err=True)
+        raise typer.Exit(2)
+
+    if spec_path is None:
+        typer.echo(f"No spec file found for issue #{issue}", err=True)
+        raise typer.Exit(1)
+
+    fm = parse_frontmatter(spec_path.read_text())
+    n = len(fm.get("checks") or [])
+    expected = list(range(n))
+
+    if all_idx != expected:
+        typer.echo(
+            f"Error: indices {all_idx} do not cover all {n} checks exactly once "
+            f"(expected {expected})",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    checked_set = set(checked_idx)
+    new_checks = [
+        {"item": c["item"], "done": i in checked_set}
+        for i, c in enumerate(fm["checks"])
+    ]
+    write_checks(spec_path, new_checks)
+
+    result = determine_state(root, issue)
+    _render_plain(result)
+```
+
+- [ ] **Step 5: Confirm pass**
+
+```bash
+cd cli && uv run pytest tests/test_cli.py -x
+```
+
+Expected: all passed
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cli/src/hexis/parser.py cli/src/hexis/cli.py cli/tests/test_cli.py
+git commit -m "feat(cli): implement status update command (#22)"
+```
+
+---
+
+### Task 9: Packaging verification [No TDD — install test]
+
+**Files:**
+- No code changes — install and smoke-test only
+
+- [ ] **Step 1: Run full test suite**
+
+```bash
+cd cli && uv run pytest
+```
+
+Expected: all tests pass, 0 failures
+
+- [ ] **Step 2: Install via `uv tool install`**
+
+```bash
+uv tool install ./cli
+```
+
+Expected: exits 0, no errors
+
+- [ ] **Step 3: Smoke-test installed binary**
+
+```bash
+hexis --help
+hexis status read --help
+hexis status update --help
+```
+
+Expected: each shows command help without errors.
+
+- [ ] **Step 4: Verify NEEDS_SPEC output with real repo**
+
+```bash
+hexis status read 999
+```
+
+Expected:
+```
+STATE: NEEDS_SPEC
+ISSUE: 999
+DEPENDS ON: (none)
+
+BLOCKING:
+  No spec file found in docs/specs/ for issue #999
+```
+
+- [ ] **Step 5: Verify real issue lookup**
+
+```bash
+hexis status read 22
+```
+
+Expected: first line is `STATE: NEEDS_VERIFY` or `STATE: IN_PROGRESS` (since spec and plan now exist for #22).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "docs: verify hexis CLI packaging and smoke tests (#22)"
+```

--- a/docs/specs/2026-04-08-hexis-cli-tool-design.md
+++ b/docs/specs/2026-04-08-hexis-cli-tool-design.md
@@ -4,9 +4,9 @@ status: READY_TO_PLAN
 checks:
   - item: "`hexis status read <issue>` outputs correct STATE label for all 5 states"
     done: false
-  - item: "`hexis status read <issue> --json` outputs valid JSON with correct `state` key and `done_when` array with indices"
+  - item: "`hexis status read <issue> --json` outputs valid JSON with correct `state` key and `checks` array with indices"
     done: false
-  - item: "`hexis status update <issue> --checked <indices> --unchecked <indices>` rewrites all Done When items atomically"
+  - item: "`hexis status update <issue> --checked <indices> --unchecked <indices>` rewrites all Checks items atomically"
     done: false
   - item: "Incomplete or overlapping index coverage exits 1 with an error message"
     done: false
@@ -31,7 +31,7 @@ A stateless Python CLI tool (`hexis`) that reads `docs/specs/` and `docs/plans/`
 | Command | Behavior |
 |---|---|
 | `hexis status read <issue>` | Parse spec/plan files; report state label, plan task progress, and indexed AC items |
-| `hexis status update <issue> --checked <indices> --unchecked <indices>` | Bulk-set all Done When AC items in one write — last-write-wins, all indices must be covered |
+| `hexis status update <issue> --checked <indices> --unchecked <indices>` | Bulk-set all Checks items in one write — last-write-wins, all indices must be covered |
 
 All commands accept `--json` for machine-readable output and `--root <path>` to specify the project root (defaults to current working directory).
 
@@ -52,24 +52,26 @@ Full `status read` example:
 ```
 STATE: NEEDS_VERIFY
 ISSUE: 21
+DEPENDS ON: (none)
 
 PLAN TASKS: 4/4 complete
 
-DONE WHEN (AC):
+CHECKS:
   [x] #0  Custom CLI tool designed with final command surface
   [ ] #1  All state transitions covered by pytest unit tests
   [ ] #2  uv tool install succeeds in a clean environment
   [x] #3  CLI handles missing docs/ directory gracefully
 ```
 
-When state is `NEEDS_SPEC` or `NEEDS_PLAN`, only the STATE/ISSUE lines and a BLOCKING reason are shown:
+When state is `NEEDS_SPEC` or `NEEDS_PLAN`, only the STATE/ISSUE/DEPENDS ON lines and a BLOCKING reason are shown:
 
 ```
 STATE: NEEDS_PLAN
-ISSUE: 21
+ISSUE: 23
+DEPENDS ON: #22
 
 BLOCKING:
-  No plan file found in docs/plans/ for issue #21
+  No plan file found in docs/plans/ for issue #23
 ```
 
 ### JSON output (`--json`)
@@ -78,8 +80,9 @@ BLOCKING:
 {
   "state": "NEEDS_VERIFY",
   "issue": 21,
+  "depends_on": [],
   "plan_tasks": { "complete": 4, "total": 4 },
-  "done_when": [
+  "checks": [
     { "index": 0, "text": "Custom CLI tool designed with final command surface", "checked": true },
     { "index": 1, "text": "All state transitions covered by pytest unit tests", "checked": false },
     { "index": 2, "text": "uv tool install succeeds in a clean environment", "checked": false },
@@ -97,11 +100,13 @@ Exit codes: `0` = success, `1` = usage/argument error, `2` = parse error (malfor
 
 The CLI scans `docs/specs/` and `docs/plans/` relative to the project root. State is computed fresh on every invocation.
 
-**Finding a spec file:** Any `docs/specs/*.md` file containing `Issue: #<N>` anywhere in the file body.
+**Finding a spec file:** Any `docs/specs/*.md` file whose YAML frontmatter `issue:` field equals `N`. If more than one file matches, exit code 2 with an error message to stderr.
 
-**Finding a plan file:** Any `docs/plans/*.md` file containing `Issue: #<N>` anywhere in the file body, OR whose YAML frontmatter contains a `linked_spec` key that points to a spec containing `Issue: #<N>`.
+**Finding a plan file:** Any `docs/plans/*.md` file whose YAML frontmatter `issue:` field equals `N`. If more than one file matches, exit code 2 with an error message to stderr.
 
-**Parsing spec Done When:** Extract all checklist items (`- [ ]` or `- [x]`) under the `## Done When` heading, up to the next `##` heading or end of file. Items are zero-indexed in the order they appear.
+**Parsing spec depends_on:** Read the `depends_on:` YAML frontmatter field if present. Value is a list of bare issue numbers (integers). Absent or empty means no dependencies. Surfaced in output as-is; not used in state determination.
+
+**Parsing spec Checks:** Read the `checks:` YAML frontmatter array. Each entry is an object with `item` (string) and `done` (boolean). Items are zero-indexed in the order they appear.
 
 **Parsing plan tasks:** Extract all checklist items (`- [ ]` or `- [x]`) anywhere in the plan file body (excluding YAML frontmatter).
 
@@ -112,8 +117,8 @@ The CLI scans `docs/specs/` and `docs/plans/` relative to the project root. Stat
 | No spec file found | `NEEDS_SPEC` |
 | Spec found, no plan file found | `NEEDS_PLAN` |
 | Plan found, any plan task item is `[ ]` | `IN_PROGRESS` |
-| All plan tasks `[x]`, any Done When item is `[ ]` | `NEEDS_VERIFY` |
-| All plan tasks `[x]`, all Done When items `[x]` | `DONE` |
+| All plan tasks `[x]`, any Checks item has `done: false` | `NEEDS_VERIFY` |
+| All plan tasks `[x]`, all Checks items have `done: true` | `DONE` |
 
 Conditions are evaluated in order. The first match determines the state.
 
@@ -126,11 +131,11 @@ A bulk, last-write-wins command. Accepts `--checked <indices>` and `--unchecked 
 hexis status update 21 --checked 0,3 --unchecked 1,2
 ```
 
-The entire Done When section is rewritten atomically from this single call. One call replaces all AC item states — no sequential per-index calls required.
+The entire `checks:` frontmatter array is rewritten atomically from this single call. One call replaces all Checks item states — no sequential per-index calls required.
 
 Outputs the new state after writing (same format as `status read`).
 
-`status update` modifies **only** Done When (AC) items in the spec file. Plan task items are read-only from the CLI's perspective.
+`status update` modifies **only** the `checks:` frontmatter field in the spec file. Plan task items are read-only from the CLI's perspective.
 
 ## Package Layout
 
@@ -141,8 +146,8 @@ cli/
     hexis/
       __init__.py
       cli.py          # Typer app, command definitions
-      parser.py       # find_spec_file, find_plan_file, parse_done_when, parse_plan_tasks
-      state.py        # determine_state, StateResult
+      parser.py       # MultipleMatchError, Check, PlanTasks; find_spec_file, find_plan_file, parse_frontmatter, parse_checks, parse_depends_on, parse_plan_tasks, write_checks
+      state.py        # State, StateResult, determine_state
   tests/
     test_parser.py
     test_state.py
@@ -155,8 +160,8 @@ Lives in the `cli/` subdirectory of the hexis repository.
 
 - Python ≥ 3.11
 - `typer` (CLI framework, includes `rich`)
+- `pyyaml` (YAML frontmatter parsing)
 - `pytest` (test runner)
-- No other runtime dependencies
 - Managed with `uv`; installable via `uv tool install ./cli`
 
 ## Out of Scope

--- a/docs/specs/2026-04-08-skill-integration-gate-design.md
+++ b/docs/specs/2026-04-08-skill-integration-gate-design.md
@@ -1,6 +1,7 @@
 ---
 issue: 23
 status: READY_TO_PLAN
+depends_on: [22]
 checks:
   - item: "`dispatch` routes via `hexis status read` output for all 5 state labels"
     done: false
@@ -8,7 +9,7 @@ checks:
     done: false
   - item: "`plan` gate runs `hexis status read` and blocks on non-`NEEDS_PLAN` state"
     done: false
-  - item: "`write-test` and `implement` gates run `hexis status read` and block on non-`IN_PROGRESS` state"
+  - item: "`implement` gate runs `hexis status read` and blocks on non-`IN_PROGRESS` state"
     done: false
   - item: "`verify` entry gate runs `hexis status read` and blocks on non-`NEEDS_VERIFY` state"
     done: false
@@ -81,7 +82,7 @@ Rules 1 (uncommitted changes) and 5–8 (PR state) remain unchanged — they sti
 - If state is `NEEDS_PLAN`: proceed
 - Otherwise: surface CLI output verbatim; stop
 
-### `write-test` and `implement`
+### `implement`
 
 **Gate position:** At skill start.
 
@@ -98,7 +99,7 @@ Rules 1 (uncommitted changes) and 5–8 (PR state) remain unchanged — they sti
 **Command:** `hexis status read <issue> --json`
 
 **Logic:**
-- If state is `NEEDS_VERIFY`: proceed — also surface the `done_when` array to the user so they know which AC items need verification
+- If state is `NEEDS_VERIFY`: proceed — also surface the `checks` array to the user so they know which items need verification
 - If state is `IN_PROGRESS`: surface blocking plan tasks from CLI output; stop — implement must complete first
 - Otherwise: surface CLI output verbatim; stop
 
@@ -106,7 +107,7 @@ Rules 1 (uncommitted changes) and 5–8 (PR state) remain unchanged — they sti
 
 **Command:** `hexis status update <issue> --checked <indices> --unchecked <indices>`
 
-**Logic:** LLM reads the `done_when` indices from the entry `read` output, determines which items have been satisfied, and calls `update` once with the complete AC state. Outputs the new state.
+**Logic:** LLM reads the `checks` indices from the entry `read` output, determines which items have been satisfied, and calls `update` once with the complete Checks state. Outputs the new state.
 
 ### `finish`
 
@@ -125,7 +126,6 @@ Rules 1 (uncommitted changes) and 5–8 (PR state) remain unchanged — they sti
 | `skills/dispatch/SKILL.md` | Replace Step 1b grep logic with `hexis status read` routing; remove `READY_TO_MERGE` from routing table |
 | `skills/specify/SKILL.md` | Add `## CLI Integration Gate` section |
 | `skills/plan/SKILL.md` | Add `## CLI Integration Gate` section |
-| `skills/write-test/SKILL.md` | Add `## CLI Integration Gate` section |
 | `skills/implement/SKILL.md` | Add `## CLI Integration Gate` section |
 | `skills/verify/SKILL.md` | Add `## CLI Integration Gate` section (entry + exit gates) |
 | `skills/finish/SKILL.md` | Add `## CLI Integration Gate` section |

--- a/skills/specify/SKILL.md
+++ b/skills/specify/SKILL.md
@@ -77,6 +77,7 @@ Write to `docs/specs/YYYY-MM-DD-<topic>-design.md`. The file must match `docs/te
 ---
 issue: N
 status: READY_TO_PLAN
+depends_on: [M, ...]   # optional — omit if no dependencies
 checks:
   - item: "criterion description"
     done: false
@@ -85,7 +86,7 @@ checks:
 # <Title>
 ```
 
-Where `N` is the GitHub issue number this spec addresses (bare integer, no `#`). If there is no associated issue, omit `issue:`. The `issue: N` frontmatter field is required for `hexis:dispatch` to locate the spec by issue number.
+Where `N` is the GitHub issue number this spec addresses (bare integer, no `#`). If there is no associated issue, omit `issue:`. The `issue: N` frontmatter field is required for `hexis:dispatch` to locate the spec by issue number. `depends_on` lists issue numbers this spec depends on (bare integers); omit if none.
 
 **HARD RULE:** The `## Done Criteria` body section is FORBIDDEN. All acceptance criteria MUST be defined in `checks:` frontmatter as a list of `{item, done}` objects. A spec file with a `## Done Criteria` body section is malformed.
 


### PR DESCRIPTION
## Summary

- Implement stateless Python CLI package (`cli/`) with `hexis status read` and `hexis status update` commands
- State is derived fresh on every invocation from `docs/specs/` and `docs/plans/` YAML frontmatter — no persistent state
- 38 pytest tests covering all 5 state transitions, file discovery, frontmatter parsing, and CLI commands

## Architecture

Three modules with a clean dependency chain: `parser.py` ← `state.py` ← `cli.py`. YAML frontmatter parsed with PyYAML. Writes atomic via `os.replace`.

## Test plan

- [ ] `hexis status read <issue>` outputs correct STATE label for all 5 states
- [ ] `hexis status read <issue> --json` outputs valid JSON with correct `state` key and `checks` array with indices
- [ ] `hexis status update <issue> --checked <indices> --unchecked <indices>` rewrites all Checks items atomically
- [ ] Incomplete or overlapping index coverage exits 1 with an error message
- [ ] All state transitions are covered by pytest unit tests (`uv run pytest` — 38 passed)
- [ ] `uv tool install ./cli` succeeds in a clean environment
- [ ] CLI handles missing `docs/` directory gracefully (outputs `NEEDS_SPEC`, exit 0)

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)