### PR TITLE
feat: add CLI integration gates to all workflow skills (#23)

### DIFF
--- a/cli/src/hexis/parser.py
+++ b/cli/src/hexis/parser.py
@@ -7,6 +7,11 @@ import tempfile
 import yaml
 
 
+class _IndentedYAMLDumper(yaml.SafeDumper):
+    def increase_indent(self, flow: bool = False, indentless: bool = False):
+        return super().increase_indent(flow, False)
+
+
 @dataclass
 class Check:
     index: int
@@ -89,7 +94,13 @@ def write_checks(path: Path, new_checks: list[dict]) -> None:
     fm = yaml.safe_load(content[4:end]) or {}
     body = content[end + 5:]
     fm["checks"] = new_checks
-    new_fm = yaml.dump(fm, default_flow_style=False, allow_unicode=True, sort_keys=False)
+    new_fm = yaml.dump(
+        fm,
+        Dumper=_IndentedYAMLDumper,
+        default_flow_style=False,
+        allow_unicode=True,
+        sort_keys=False,
+    )
     new_content = f"---\n{new_fm}---\n{body}"
     with tempfile.NamedTemporaryFile(
         mode="w", dir=path.parent, delete=False, suffix=".tmp", encoding="utf-8"

--- a/cli/tests/test_parser.py
+++ b/cli/tests/test_parser.py
@@ -1,4 +1,4 @@
-from hexis.parser import parse_frontmatter
+from hexis.parser import parse_frontmatter, write_checks
 
 def test_parse_frontmatter_valid():
     content = "---\nissue: 5\nstatus: READY_TO_PLAN\n---\n\n# Title\n"
@@ -110,3 +110,22 @@ def test_parse_plan_tasks_none():
 def test_parse_plan_tasks_excludes_frontmatter():
     content = "---\nchecks:\n  - item: x\n    done: false\n---\n\n- [x] Real task\n"
     assert parse_plan_tasks(content) == PlanTasks(complete=1, total=1)
+
+
+def test_write_checks_indents_items_under_checks(tmp_path):
+    spec_path = tmp_path / "spec.md"
+    spec_path.write_text(
+        "---\nissue: 5\nchecks:\n  - item: Old\n    done: false\n---\n\n# Spec\n"
+    )
+
+    write_checks(
+        spec_path,
+        [
+            {"item": "First criterion", "done": True},
+            {"item": "Second criterion", "done": False},
+        ],
+    )
+
+    content = spec_path.read_text()
+    assert "checks:\n  - item: First criterion\n    done: true\n  - item: Second criterion\n    done: false\n" in content
+    assert "checks:\n- item:" not in content

--- a/docs/plans/2026-04-29-skill-integration-gate.md
+++ b/docs/plans/2026-04-29-skill-integration-gate.md
@@ -1,0 +1,348 @@
+---
+issue: 23
+status: READY_TO_IMPLEMENT
+linked_spec: docs/specs/2026-04-08-skill-integration-gate-design.md
+---
+
+# Skill Integration Gate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `hexis:implement` to execute task by task. For TDD tasks, follow `hexis:testing-principles`. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add CLI integration gates to all 6 hexis workflow skills, replacing LLM-driven state judgment with `hexis status read/update` output.
+
+**Architecture:** Each skill gets a `## CLI Integration Gate` section that runs `hexis status read <issue>` at entry and blocks if the state does not match the required label. `dispatch` replaces its grep-based routing with `hexis status read --json` output. `verify` additionally gets an exit gate that calls `hexis status update` inside the existing Gate Function, inserted before SYNC so the spec change is captured in the same commit.
+
+**Tech Stack:** Markdown skill files (no code changes), `hexis` CLI (implemented in #22)
+
+> Decomposition considered: all 6 tasks touch separate files with no cross-task conflicts and are individually mergeable, but partial deployment leaves the system inconsistent — only some skills gated while others use old grep logic. Single plan retained.
+
+---
+
+## Spec Check → Task Mapping
+
+| Spec check index | Spec check item | Task |
+|---|---|---|
+| 0 | `dispatch` routes via `hexis status read` for all 5 state labels | Task 1 |
+| 1 | `specify` gate blocks overwrite of existing spec without confirmation | Task 2 |
+| 2 | `plan` gate blocks on non-`NEEDS_PLAN` state | Task 3 |
+| 3 | `implement` gate blocks on non-`IN_PROGRESS` state | Task 4 |
+| 4 | `verify` entry gate blocks on non-`NEEDS_VERIFY` state | Task 5 |
+| 5 | `verify` exit gate runs `hexis status update` with complete AC state | Task 5 |
+| 6 | `finish` gate blocks on non-`DONE` state | Task 6 |
+
+---
+
+## Files
+
+| File | Change |
+|---|---|
+| `skills/dispatch/SKILL.md` | Replace Step 1b grep commands with `hexis status read --json`; replace routing Rules 2–4 with 5 CLI-state rules; renumber downstream rules |
+| `skills/specify/SKILL.md` | Add `## CLI Integration Gate` section after `## $ARGUMENTS` |
+| `skills/plan/SKILL.md` | Add `## CLI Integration Gate` section after `## $ARGUMENTS` |
+| `skills/implement/SKILL.md` | Add `## CLI Integration Gate` section after `## $ARGUMENTS` |
+| `skills/verify/SKILL.md` | Add `## CLI Integration Gate` section (entry gate) after `## $ARGUMENTS`; insert exit gate step in existing `## Gate Function` |
+| `skills/finish/SKILL.md` | Add `## CLI Integration Gate` section after `## $ARGUMENTS` |
+
+---
+
+## Task 1: Update `dispatch` routing to use `hexis status read` [No TDD — skill file (markdown)]
+
+**Files:**
+- Modify: `skills/dispatch/SKILL.md`
+
+- [ ] **Step 1: Implement**
+
+Replace the Step 1b bash block and variable descriptions (lines 56–67 of current file):
+
+**Old — Step 1b bash block:**
+```
+Run in parallel:
+
+```bash
+grep -rl "^issue: N$" docs/specs/ 2>/dev/null
+grep -rl "^issue: N$" docs/plans/ 2>/dev/null
+gh pr list --head $(git branch --show-current) --json number,state,isDraft,reviewDecision,statusCheckRollup --limit 1
+```
+
+Where `N` is the literal issue number (e.g., for issue 20: `grep -rl "^issue: 20$" docs/specs/ 2>/dev/null`).
+
+Collect:
+- `spec_found`: true if any file in `docs/specs/` has frontmatter line `issue: N`
+- `plan_found`: true if any file in `docs/plans/` has frontmatter line `issue: N`
+- `pr`: the PR object from `gh`, or empty if none
+```
+
+**New — Step 1b bash block:**
+```
+Run in parallel:
+
+```bash
+hexis status read N --json
+gh pr list --head $(git branch --show-current) --json number,state,isDraft,reviewDecision,statusCheckRollup --limit 1
+```
+
+Where `N` is the literal issue number (e.g., for issue 20: `hexis status read 20 --json`).
+
+Collect:
+- `status`: the full JSON object from `hexis status read --json` (contains `state`, `issue`, `plan_tasks`, `checks`, `blocking`)
+- `pr`: the PR object from `gh`, or empty if none
+```
+
+Replace the routing table (Rules 1–8):
+
+**Old routing table:**
+```
+| Rule | Condition | Next Skill |
+|------|-----------|-----------|
+| 1 | `git status --short` output is non-empty | `sync-working-status` |
+| 2 | `spec_found` is false | `specify` |
+| 3 | `spec_found` is true AND `plan_found` is false | `plan` |
+| 4 | `plan_found` is true AND (no PR exists OR PR is draft) | `implement` |
+| 5 | PR open AND any check is failing | `verify` |
+| 6 | PR open AND all checks passing AND review not approved | `review` |
+| 7 | PR open AND approved | `finish` |
+| 8 | PR merged | — (stop, see below) |
+```
+
+**New routing table:**
+```
+| Rule | Condition | Next Skill |
+|------|-----------|-----------|
+| 1 | `git status --short` output is non-empty | `sync-working-status` |
+| 2 | `status.state` is `NEEDS_SPEC` | `specify` |
+| 3 | `status.state` is `NEEDS_PLAN` | `plan` |
+| 4 | `status.state` is `IN_PROGRESS` | `implement` |
+| 5 | `status.state` is `NEEDS_VERIFY` | `verify` |
+| 6 | `status.state` is `DONE` AND no open PR | — (stop: output "Issue #N is complete. Nothing to dispatch.") |
+| 7 | PR open AND any check is failing | `verify` |
+| 8 | PR open AND all checks passing AND review not approved | `review` |
+| 9 | PR open AND approved | `finish` |
+| 10 | PR merged | — (stop, see below) |
+```
+
+Change "**Rule 8 — PR merged:**" heading to "**Rule 10 — PR merged:**".
+
+Replace the first bullet in `## Notes`:
+
+**Old:**
+```
+- If spec/plan files do not have `issue: N` in their YAML frontmatter, dispatch cannot locate them — they are treated as non-existent, and dispatch routes to `specify` or `plan` accordingly.
+```
+
+**New:**
+```
+- `hexis status read` is the authoritative source for issue state. The LLM does not infer state from file presence independently — CLI output determines routing.
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `grep -n "hexis status read\|status\.state\|Rule 10" skills/dispatch/SKILL.md`
+
+Expected: Lines showing `hexis status read N --json` in Step 1b, five `status.state` routing conditions in Step 2, and `Rule 10 — PR merged` in the rule description section.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/dispatch/SKILL.md
+git commit -m "feat(dispatch): route via hexis status read instead of grep (#23)"
+```
+
+---
+
+## Task 2: Add CLI integration gate to `specify` [No TDD — skill file (markdown)]
+
+**Files:**
+- Modify: `skills/specify/SKILL.md`
+
+- [ ] **Step 1: Implement**
+
+Insert the following section after `## $ARGUMENTS` and before `## Checklist` in `skills/specify/SKILL.md`:
+
+```markdown
+## CLI Integration Gate
+
+If an issue number is known from `$ARGUMENTS` or session context (e.g., the current branch is `feat/23-something`):
+
+1. Run: `hexis status read <issue>`
+2. If output shows `STATE: NEEDS_SPEC`: proceed.
+3. If output shows any other state: a spec already exists for this issue. Surface the full CLI output verbatim to the user and ask for explicit confirmation before overwriting. Do not proceed without confirmation.
+
+If no issue number is known (genuinely new work with no GitHub issue yet): skip this gate and proceed.
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `grep -A 12 "## CLI Integration Gate" skills/specify/SKILL.md`
+
+Expected: Shows the 4-line gate section ending with "skip this gate and proceed."
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/specify/SKILL.md
+git commit -m "feat(specify): add CLI integration gate (#23)"
+```
+
+---
+
+## Task 3: Add CLI integration gate to `plan` [No TDD — skill file (markdown)]
+
+**Files:**
+- Modify: `skills/plan/SKILL.md`
+
+- [ ] **Step 1: Implement**
+
+Insert the following section after `## $ARGUMENTS` and before `## Scope Check` in `skills/plan/SKILL.md`:
+
+```markdown
+## CLI Integration Gate
+
+After loading the spec and reading the `issue:` value from its frontmatter, before writing any plan content:
+
+1. Run: `hexis status read <issue>`
+2. If output shows `STATE: NEEDS_PLAN`: proceed.
+3. If output shows any other state: surface the full CLI output verbatim to the user; stop. Do not write any plan content.
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `grep -A 7 "## CLI Integration Gate" skills/plan/SKILL.md`
+
+Expected: Shows the 3-step gate section ending with "Do not write any plan content."
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/plan/SKILL.md
+git commit -m "feat(plan): add CLI integration gate (#23)"
+```
+
+---
+
+## Task 4: Add CLI integration gate to `implement` [No TDD — skill file (markdown)]
+
+**Files:**
+- Modify: `skills/implement/SKILL.md`
+
+- [ ] **Step 1: Implement**
+
+Insert the following section after `## $ARGUMENTS` and before `## Complexity Check` in `skills/implement/SKILL.md`:
+
+```markdown
+## CLI Integration Gate
+
+After loading the plan and reading the `issue:` value from its frontmatter, before writing any code:
+
+1. Run: `hexis status read <issue>`
+2. If output shows `STATE: IN_PROGRESS`: proceed.
+3. If output shows any other state: surface the full CLI output verbatim to the user; stop. Do not begin implementation.
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `grep -A 7 "## CLI Integration Gate" skills/implement/SKILL.md`
+
+Expected: Shows the 3-step gate section ending with "Do not begin implementation."
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/implement/SKILL.md
+git commit -m "feat(implement): add CLI integration gate (#23)"
+```
+
+---
+
+## Task 5: Add CLI integration gate (entry + exit) to `verify` [No TDD — skill file (markdown)]
+
+**Files:**
+- Modify: `skills/verify/SKILL.md`
+
+- [ ] **Step 1: Implement — entry gate section**
+
+Insert the following section after `## $ARGUMENTS` and before `## Complexity Check` in `skills/verify/SKILL.md`:
+
+```markdown
+## CLI Integration Gate
+
+### Entry Gate
+
+At skill start, before running any verification commands:
+
+1. Obtain the issue number: use the number in `$ARGUMENTS` if provided; otherwise infer from the current branch name (first integer after the last `/`) or ask the user.
+2. Run: `hexis status read <issue> --json`
+3. If `state` is `NEEDS_VERIFY`: proceed. Surface the `checks` array to the user so they know which items need verification.
+4. If `state` is `IN_PROGRESS`: surface the full CLI output verbatim to the user (blocking plan tasks are shown); stop — implementation must complete first.
+5. If `state` is any other value: surface the full CLI output verbatim to the user; stop.
+```
+
+- [ ] **Step 2: Implement — exit gate inside existing `## Gate Function`**
+
+In `## Gate Function`, the current step sequence is:
+
+```
+5. SYNC: invoke hexis:sync-working-status
+6. ONLY THEN: claim
+```
+
+Replace it with:
+
+```
+5. UPDATE: run `hexis status update <issue> --checked <satisfied-indices> --unchecked <unsatisfied-indices>` using the checks from the entry gate read output (exit gate — updates spec before sync so the change is included in the commit)
+6. SYNC: invoke hexis:sync-working-status
+7. ONLY THEN: claim
+```
+
+- [ ] **Step 3: Verify**
+
+Run: `grep -A 15 "## CLI Integration Gate" skills/verify/SKILL.md`
+
+Expected: Shows the entry gate section with 5 steps. Then run:
+
+```bash
+grep -A 10 "## Gate Function" skills/verify/SKILL.md
+```
+
+Expected: Steps 5 UPDATE, 6 SYNC, 7 ONLY THEN visible in sequence.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add skills/verify/SKILL.md
+git commit -m "feat(verify): add CLI integration gate with exit update (#23)"
+```
+
+---
+
+## Task 6: Add CLI integration gate to `finish` [No TDD — skill file (markdown)]
+
+**Files:**
+- Modify: `skills/finish/SKILL.md`
+
+- [ ] **Step 1: Implement**
+
+Insert the following section after `## $ARGUMENTS` and before `## Process` in `skills/finish/SKILL.md`:
+
+```markdown
+## CLI Integration Gate
+
+Before any commit, push, or PR creation:
+
+1. Obtain the issue number: use the number in `$ARGUMENTS` if provided; otherwise infer from the current branch name (first integer after the last `/`) or ask the user.
+2. Run: `hexis status read <issue>`
+3. If output shows `STATE: DONE`: proceed.
+4. If output shows any other state: surface the full CLI output verbatim to the user; stop. Do not proceed with commit, push, or PR creation.
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `grep -A 8 "## CLI Integration Gate" skills/finish/SKILL.md`
+
+Expected: Shows the 4-step gate section ending with "Do not proceed with commit, push, or PR creation."
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/finish/SKILL.md
+git commit -m "feat(finish): add CLI integration gate (#23)"
+```

--- a/docs/plans/2026-04-29-skill-integration-gate.md
+++ b/docs/plans/2026-04-29-skill-integration-gate.md
@@ -6,7 +6,7 @@ linked_spec: docs/specs/2026-04-08-skill-integration-gate-design.md
 
 # Skill Integration Gate Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use `hexis:implement` to execute task by task. For TDD tasks, follow `hexis:testing-principles`. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `hexis:implement` to execute task by task. For TDD tasks, follow `hexis:testing-principles`. Steps use checkbox (`- [x]`) syntax for tracking.
 
 **Goal:** Add CLI integration gates to all 6 hexis workflow skills, replacing LLM-driven state judgment with `hexis status read/update` output.
 
@@ -50,7 +50,7 @@ linked_spec: docs/specs/2026-04-08-skill-integration-gate-design.md
 **Files:**
 - Modify: `skills/dispatch/SKILL.md`
 
-- [ ] **Step 1: Implement**
+- [x] **Step 1: Implement**
 
 Replace the Step 1b bash block and variable descriptions (lines 56–67 of current file):
 
@@ -134,13 +134,13 @@ Replace the first bullet in `## Notes`:
 - `hexis status read` is the authoritative source for issue state. The LLM does not infer state from file presence independently — CLI output determines routing.
 ```
 
-- [ ] **Step 2: Verify**
+- [x] **Step 2: Verify**
 
 Run: `grep -n "hexis status read\|status\.state\|Rule 10" skills/dispatch/SKILL.md`
 
 Expected: Lines showing `hexis status read N --json` in Step 1b, five `status.state` routing conditions in Step 2, and `Rule 10 — PR merged` in the rule description section.
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 git add skills/dispatch/SKILL.md
@@ -154,7 +154,7 @@ git commit -m "feat(dispatch): route via hexis status read instead of grep (#23)
 **Files:**
 - Modify: `skills/specify/SKILL.md`
 
-- [ ] **Step 1: Implement**
+- [x] **Step 1: Implement**
 
 Insert the following section after `## $ARGUMENTS` and before `## Checklist` in `skills/specify/SKILL.md`:
 
@@ -170,13 +170,13 @@ If an issue number is known from `$ARGUMENTS` or session context (e.g., the curr
 If no issue number is known (genuinely new work with no GitHub issue yet): skip this gate and proceed.
 ```
 
-- [ ] **Step 2: Verify**
+- [x] **Step 2: Verify**
 
 Run: `grep -A 12 "## CLI Integration Gate" skills/specify/SKILL.md`
 
 Expected: Shows the 4-line gate section ending with "skip this gate and proceed."
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 git add skills/specify/SKILL.md
@@ -190,7 +190,7 @@ git commit -m "feat(specify): add CLI integration gate (#23)"
 **Files:**
 - Modify: `skills/plan/SKILL.md`
 
-- [ ] **Step 1: Implement**
+- [x] **Step 1: Implement**
 
 Insert the following section after `## $ARGUMENTS` and before `## Scope Check` in `skills/plan/SKILL.md`:
 
@@ -204,13 +204,13 @@ After loading the spec and reading the `issue:` value from its frontmatter, befo
 3. If output shows any other state: surface the full CLI output verbatim to the user; stop. Do not write any plan content.
 ```
 
-- [ ] **Step 2: Verify**
+- [x] **Step 2: Verify**
 
 Run: `grep -A 7 "## CLI Integration Gate" skills/plan/SKILL.md`
 
 Expected: Shows the 3-step gate section ending with "Do not write any plan content."
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 git add skills/plan/SKILL.md
@@ -224,7 +224,7 @@ git commit -m "feat(plan): add CLI integration gate (#23)"
 **Files:**
 - Modify: `skills/implement/SKILL.md`
 
-- [ ] **Step 1: Implement**
+- [x] **Step 1: Implement**
 
 Insert the following section after `## $ARGUMENTS` and before `## Complexity Check` in `skills/implement/SKILL.md`:
 
@@ -238,13 +238,13 @@ After loading the plan and reading the `issue:` value from its frontmatter, befo
 3. If output shows any other state: surface the full CLI output verbatim to the user; stop. Do not begin implementation.
 ```
 
-- [ ] **Step 2: Verify**
+- [x] **Step 2: Verify**
 
 Run: `grep -A 7 "## CLI Integration Gate" skills/implement/SKILL.md`
 
 Expected: Shows the 3-step gate section ending with "Do not begin implementation."
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 git add skills/implement/SKILL.md
@@ -258,7 +258,7 @@ git commit -m "feat(implement): add CLI integration gate (#23)"
 **Files:**
 - Modify: `skills/verify/SKILL.md`
 
-- [ ] **Step 1: Implement — entry gate section**
+- [x] **Step 1: Implement — entry gate section**
 
 Insert the following section after `## $ARGUMENTS` and before `## Complexity Check` in `skills/verify/SKILL.md`:
 
@@ -276,7 +276,7 @@ At skill start, before running any verification commands:
 5. If `state` is any other value: surface the full CLI output verbatim to the user; stop.
 ```
 
-- [ ] **Step 2: Implement — exit gate inside existing `## Gate Function`**
+- [x] **Step 2: Implement — exit gate inside existing `## Gate Function`**
 
 In `## Gate Function`, the current step sequence is:
 
@@ -293,7 +293,7 @@ Replace it with:
 7. ONLY THEN: claim
 ```
 
-- [ ] **Step 3: Verify**
+- [x] **Step 3: Verify**
 
 Run: `grep -A 15 "## CLI Integration Gate" skills/verify/SKILL.md`
 
@@ -305,7 +305,7 @@ grep -A 10 "## Gate Function" skills/verify/SKILL.md
 
 Expected: Steps 5 UPDATE, 6 SYNC, 7 ONLY THEN visible in sequence.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add skills/verify/SKILL.md
@@ -319,7 +319,7 @@ git commit -m "feat(verify): add CLI integration gate with exit update (#23)"
 **Files:**
 - Modify: `skills/finish/SKILL.md`
 
-- [ ] **Step 1: Implement**
+- [x] **Step 1: Implement**
 
 Insert the following section after `## $ARGUMENTS` and before `## Process` in `skills/finish/SKILL.md`:
 
@@ -334,13 +334,13 @@ Before any commit, push, or PR creation:
 4. If output shows any other state: surface the full CLI output verbatim to the user; stop. Do not proceed with commit, push, or PR creation.
 ```
 
-- [ ] **Step 2: Verify**
+- [x] **Step 2: Verify**
 
 Run: `grep -A 8 "## CLI Integration Gate" skills/finish/SKILL.md`
 
 Expected: Shows the 4-step gate section ending with "Do not proceed with commit, push, or PR creation."
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 git add skills/finish/SKILL.md

--- a/docs/specs/2026-04-08-hexis-cli-tool-design.md
+++ b/docs/specs/2026-04-08-hexis-cli-tool-design.md
@@ -2,20 +2,23 @@
 issue: 22
 status: READY_TO_PLAN
 checks:
-  - item: "`hexis status read <issue>` outputs correct STATE label for all 5 states"
-    done: false
-  - item: "`hexis status read <issue> --json` outputs valid JSON with correct `state` key and `checks` array with indices"
-    done: false
-  - item: "`hexis status update <issue> --checked <indices> --unchecked <indices>` rewrites all Checks items atomically"
-    done: false
-  - item: "Incomplete or overlapping index coverage exits 1 with an error message"
-    done: false
-  - item: "All state transitions are covered by pytest unit tests"
-    done: false
-  - item: "`uv tool install ./cli` succeeds in a clean environment"
-    done: false
-  - item: "CLI handles missing `docs/` directory gracefully (outputs `NEEDS_SPEC`, exit 0)"
-    done: false
+  - item: '`hexis status read <issue>` outputs correct STATE label for all 5 states'
+    done: true
+  - item: '`hexis status read <issue> --json` outputs valid JSON with correct `state`
+      key and `checks` array with indices'
+    done: true
+  - item: '`hexis status update <issue> --checked <indices> --unchecked <indices>`
+      rewrites all Checks items atomically'
+    done: true
+  - item: Incomplete or overlapping index coverage exits 1 with an error message
+    done: true
+  - item: All state transitions are covered by pytest unit tests
+    done: true
+  - item: '`uv tool install ./cli` succeeds in a clean environment'
+    done: true
+  - item: CLI handles missing `docs/` directory gracefully (outputs `NEEDS_SPEC`,
+      exit 0)
+    done: true
 ---
 
 # hexis CLI Tool

--- a/docs/specs/2026-04-08-skill-integration-gate-design.md
+++ b/docs/specs/2026-04-08-skill-integration-gate-design.md
@@ -1,6 +1,6 @@
 ---
 issue: 23
-status: READY_TO_PLAN
+status: IN_PROGRESS
 depends_on: [22]
 checks:
   - item: "`dispatch` routes via `hexis status read` output for all 5 state labels"

--- a/docs/specs/2026-04-08-skill-integration-gate-design.md
+++ b/docs/specs/2026-04-08-skill-integration-gate-design.md
@@ -1,22 +1,28 @@
 ---
 issue: 23
 status: IN_PROGRESS
-depends_on: [22]
+depends_on:
+- 22
 checks:
-  - item: "`dispatch` routes via `hexis status read` output for all 5 state labels"
-    done: false
-  - item: "`specify` gate runs `hexis status read` and blocks overwrite of existing spec without confirmation"
-    done: false
-  - item: "`plan` gate runs `hexis status read` and blocks on non-`NEEDS_PLAN` state"
-    done: false
-  - item: "`implement` gate runs `hexis status read` and blocks on non-`IN_PROGRESS` state"
-    done: false
-  - item: "`verify` entry gate runs `hexis status read` and blocks on non-`NEEDS_VERIFY` state"
-    done: false
-  - item: "`verify` exit gate runs `hexis status update` with complete AC state after verification"
-    done: false
-  - item: "`finish` gate runs `hexis status read` at entry and blocks on non-`DONE` state"
-    done: false
+- item: '`dispatch` routes via `hexis status read` output for all 5 state labels'
+  done: true
+- item: '`specify` gate runs `hexis status read` and blocks overwrite of existing
+    spec without confirmation'
+  done: true
+- item: '`plan` gate runs `hexis status read` and blocks on non-`NEEDS_PLAN` state'
+  done: true
+- item: '`implement` gate runs `hexis status read` and blocks on non-`IN_PROGRESS`
+    state'
+  done: true
+- item: '`verify` entry gate runs `hexis status read` and blocks on non-`NEEDS_VERIFY`
+    state'
+  done: true
+- item: '`verify` exit gate runs `hexis status update` with complete AC state after
+    verification'
+  done: true
+- item: '`finish` gate runs `hexis status read` at entry and blocks on non-`DONE`
+    state'
+  done: true
 ---
 
 # Skill Integration Gate

--- a/docs/specs/2026-04-08-skill-integration-gate-design.md
+++ b/docs/specs/2026-04-08-skill-integration-gate-design.md
@@ -2,27 +2,27 @@
 issue: 23
 status: IN_PROGRESS
 depends_on:
-- 22
+  - 22
 checks:
-- item: '`dispatch` routes via `hexis status read` output for all 5 state labels'
-  done: true
-- item: '`specify` gate runs `hexis status read` and blocks overwrite of existing
-    spec without confirmation'
-  done: true
-- item: '`plan` gate runs `hexis status read` and blocks on non-`NEEDS_PLAN` state'
-  done: true
-- item: '`implement` gate runs `hexis status read` and blocks on non-`IN_PROGRESS`
-    state'
-  done: true
-- item: '`verify` entry gate runs `hexis status read` and blocks on non-`NEEDS_VERIFY`
-    state'
-  done: true
-- item: '`verify` exit gate runs `hexis status update` with complete AC state after
-    verification'
-  done: true
-- item: '`finish` gate runs `hexis status read` at entry and blocks on non-`DONE`
-    state'
-  done: true
+  - item: '`dispatch` routes via `hexis status read` output for all 5 state labels'
+    done: true
+  - item: '`specify` gate runs `hexis status read` and blocks overwrite of existing
+      spec without confirmation'
+    done: true
+  - item: '`plan` gate runs `hexis status read` and blocks on non-`NEEDS_PLAN` state'
+    done: true
+  - item: '`implement` gate runs `hexis status read` and blocks on non-`IN_PROGRESS`
+      state'
+    done: true
+  - item: '`verify` entry gate runs `hexis status read` and blocks on non-`NEEDS_VERIFY`
+      state'
+    done: true
+  - item: '`verify` exit gate runs `hexis status update` with complete AC state after
+      verification'
+    done: true
+  - item: '`finish` gate runs `hexis status read` at entry and blocks on non-`DONE`
+      state'
+    done: true
 ---
 
 # Skill Integration Gate

--- a/docs/specs/2026-05-02-frontmatter-authority-design.md
+++ b/docs/specs/2026-05-02-frontmatter-authority-design.md
@@ -1,0 +1,184 @@
+---
+issue: 37
+status: READY_TO_PLAN
+depends_on: [22]
+checks:
+  - item: "`hexis status update <issue>` rewrites both spec.status and plan.status from the to-be derived workflow state"
+    done: false
+  - item: "CLI is the authoritative reader/writer for frontmatter state transitions; status values are no longer maintained manually"
+    done: false
+  - item: "`depends_on` is accepted only in YAML flow-sequence form (`depends_on: [22, 23]`)"
+    done: false
+  - item: "Legacy block-sequence `depends_on` syntax is rejected by CLI parsing with a deterministic error"
+    done: false
+  - item: "Existing spec and plan files using block-sequence `depends_on` are migrated to flow-sequence form"
+    done: false
+  - item: "`checks` remains block-sequence YAML and is not converted to flow style"
+    done: false
+  - item: "Pytest coverage includes frontmatter rewriting, status synchronization, and legacy `depends_on` rejection"
+    done: false
+---
+
+# Make hexis CLI Authoritative for Frontmatter State
+
+## Problem
+
+The current CLI derives workflow state from spec and plan frontmatter, but it does not fully own that frontmatter as the authoritative state manager.
+
+Two inconsistencies remain:
+
+1. `hexis status update` rewrites `checks:` but leaves `status:` fields stale, so file metadata can disagree with the derived workflow state.
+2. `depends_on:` formatting is inconsistent across the repository. Both YAML block-sequence and flow-sequence forms are currently representable, which weakens deterministic parsing and formatting rules.
+
+This creates split ownership: the CLI reads workflow state, but humans still have to maintain part of that state manually.
+
+## Goal
+
+Make `hexis` CLI the authoritative owner of workflow frontmatter state.
+
+After this change:
+- the CLI reads frontmatter
+- the CLI determines the resulting workflow state
+- the CLI rewrites all frontmatter fields whose values are statically derivable from repository content
+- frontmatter syntax rules are explicit, enforced, and normalized
+
+## Changes
+
+### 1. Promote CLI to authoritative frontmatter manager
+
+`hexis` becomes the single authority for frontmatter fields that encode workflow state.
+
+For this scope, authoritative ownership means:
+- parsing frontmatter into typed CLI state
+- validating frontmatter syntax against repo rules
+- computing the to-be workflow state from current files
+- rewriting frontmatter fields whose values are deterministically derivable
+
+Humans may still author specs and plans, but they no longer manually maintain derived workflow status values as the source of truth.
+
+### 2. Extend `status update` to rewrite both `checks` and `status`
+
+`hexis status update <issue>` must no longer update only `checks:`.
+
+After applying the requested checked/unchecked indices, the CLI must recompute the to-be workflow state from the full repository view and then rewrite all statically derivable `status:` fields affected by that state.
+
+Minimum rewrite scope:
+- spec frontmatter: `status`
+- plan frontmatter: `status`
+- spec frontmatter: `checks`
+
+The command must inspect all relevant fields needed to derive the resulting state, not just the previous `checks` values.
+
+### 3. Canonical status mapping
+
+The canonical status values remain document-type-specific:
+
+**Spec status values**
+- `READY_TO_PLAN`
+- `IN_PROGRESS`
+- `NEEDS_VERIFY`
+- `DONE`
+
+**Plan status values**
+- `READY_TO_IMPLEMENT`
+- `IN_PROGRESS`
+- `DONE`
+
+The CLI derives these values from the to-be workflow state and rewrites them accordingly.
+
+Required mapping:
+
+| Derived workflow state | spec.status | plan.status |
+|---|---|---|
+| `NEEDS_PLAN` | `READY_TO_PLAN` | no plan file exists |
+| `IN_PROGRESS` | `IN_PROGRESS` | `IN_PROGRESS` |
+| `NEEDS_VERIFY` | `NEEDS_VERIFY` | `DONE` |
+| `DONE` | `DONE` | `DONE` |
+
+`status update` operates only when a spec file exists. If a plan file also exists, its `status` must be rewritten in the same operation.
+
+### 4. Keep `checks` as block sequence
+
+The `checks:` field remains a YAML block sequence and is not converted to flow style.
+
+Valid form:
+
+```yaml
+checks:
+  - item: "criterion"
+    done: false
+```
+
+Changing `checks` to flow style is out of scope.
+
+### 5. Enforce `depends_on` as flow sequence only
+
+`depends_on:` must use YAML flow-sequence syntax only.
+
+Valid form:
+
+```yaml
+depends_on: [22, 23]
+```
+
+Invalid form:
+
+```yaml
+depends_on:
+  - 22
+  - 23
+```
+
+This is a repository rule, not a YAML limitation. Both forms are legal YAML, but only the flow-sequence form is allowed in hexis documents after this change.
+
+### 6. Hard rejection of legacy `depends_on` syntax
+
+Legacy block-sequence `depends_on` syntax is unsupported.
+
+If the CLI encounters:
+
+```yaml
+depends_on:
+  - 22
+```
+
+it must fail deterministically rather than silently accept or normalize it.
+
+Failure requirements:
+- non-zero exit
+- clear error message explaining that `depends_on` must use flow-sequence syntax
+- no partial rewrite
+
+This enforcement applies to CLI reads and writes. Old syntax is not supported as a fallback mode.
+
+### 7. Repository migration
+
+All existing spec and plan files using block-sequence `depends_on` must be migrated to flow-sequence form.
+
+After migration:
+- repository documents use one canonical `depends_on` format
+- CLI tests and fixtures use only the canonical format, except where a legacy-format rejection test intentionally covers failure behavior
+- documentation examples match the enforced format
+
+### 8. Parsing and writing implications
+
+Because YAML parsers normalize both block and flow sequences to the same in-memory list value, syntax enforcement cannot rely on parsed data alone.
+
+The CLI must distinguish between:
+- semantic value of `depends_on`
+- raw source syntax used to express `depends_on`
+
+That means parsing/validation must inspect raw frontmatter text when enforcing the `depends_on` formatting rule.
+
+The writer must also preserve the new repository contract:
+- `depends_on` is emitted in flow style
+- `checks` is emitted in block style
+- rewritten frontmatter remains deterministic across repeated writes
+
+## Out of Scope
+
+- Adding network-based state sources or GitHub API integration to the CLI
+- Changing the meaning of the workflow state machine itself
+- Converting `checks` to flow-style YAML
+- Preserving backward compatibility for legacy block-style `depends_on`
+- Auto-correcting invalid legacy `depends_on` syntax during read operations without an explicit migration change

--- a/skills/dispatch/SKILL.md
+++ b/skills/dispatch/SKILL.md
@@ -54,16 +54,14 @@ Ask the user: "What issue number are you working on? Enter the number, or 'none'
 Run in parallel:
 
 ```bash
-grep -rl "^issue: N$" docs/specs/ 2>/dev/null
-grep -rl "^issue: N$" docs/plans/ 2>/dev/null
+hexis status read N --json
 gh pr list --head $(git branch --show-current) --json number,state,isDraft,reviewDecision,statusCheckRollup --limit 1
 ```
 
-Where `N` is the literal issue number (e.g., for issue 20: `grep -rl "^issue: 20$" docs/specs/ 2>/dev/null`).
+Where `N` is the literal issue number (e.g., for issue 20: `hexis status read 20 --json`).
 
 Collect:
-- `spec_found`: true if any file in `docs/specs/` has frontmatter line `issue: N`
-- `plan_found`: true if any file in `docs/plans/` has frontmatter line `issue: N`
+- `status`: the full JSON object from `hexis status read --json` (contains `state`, `issue`, `plan_tasks`, `checks`, `blocking`)
 - `pr`: the PR object from `gh`, or empty if none
 
 ## Step 2: Routing
@@ -73,13 +71,15 @@ Apply the **first matching rule** in this order:
 | Rule | Condition | Next Skill |
 |------|-----------|-----------|
 | 1 | `git status --short` output is non-empty | `sync-working-status` |
-| 2 | `spec_found` is false | `specify` |
-| 3 | `spec_found` is true AND `plan_found` is false | `plan` |
-| 4 | `plan_found` is true AND (no PR exists OR PR is draft) | `implement` |
-| 5 | PR open AND any check is failing | `verify` |
-| 6 | PR open AND all checks passing AND review not approved | `review` |
-| 7 | PR open AND approved | `finish` |
-| 8 | PR merged | — (stop, see below) |
+| 2 | `status.state` is `NEEDS_SPEC` | `specify` |
+| 3 | `status.state` is `NEEDS_PLAN` | `plan` |
+| 4 | `status.state` is `IN_PROGRESS` | `implement` |
+| 5 | `status.state` is `NEEDS_VERIFY` | `verify` |
+| 6 | `status.state` is `DONE` AND no open PR | — (stop: output "Issue #N is complete. Nothing to dispatch.") |
+| 7 | PR open AND any check is failing | `verify` |
+| 8 | PR open AND all checks passing AND review not approved | `review` |
+| 9 | PR open AND approved | `finish` |
+| 10 | PR merged | — (stop, see below) |
 
 **Rule 1 — sync-working-status special handling:**
 
@@ -91,7 +91,7 @@ After it completes, re-run hexis:dispatch to continue.
 
 Invoke `hexis:sync-working-status`. Do NOT continue routing after sync — stop dispatch here. The user re-invokes dispatch manually.
 
-**Rule 8 — PR merged:**
+**Rule 10 — PR merged:**
 
 Output:
 ```
@@ -113,5 +113,5 @@ Then immediately invoke the determined skill. No confirmation prompt.
 
 ## Notes
 
-- If spec/plan files do not have `issue: N` in their YAML frontmatter, dispatch cannot locate them — they are treated as non-existent, and dispatch routes to `specify` or `plan` accordingly.
+- `hexis status read` is the authoritative source for issue state. The LLM does not infer state from file presence independently — CLI output determines routing.
 - Multiple issues on one branch: dispatch uses the first integer found in the branch name. If this is wrong, pass the correct issue number when asked.

--- a/skills/finish/SKILL.md
+++ b/skills/finish/SKILL.md
@@ -14,6 +14,15 @@ Verify → commit → choose integration method → execute → clean up.
 
 If `$ARGUMENTS` contains a branch or feature description, use it as context.
 
+## CLI Integration Gate
+
+Before any commit, push, or PR creation:
+
+1. Obtain the issue number: use the number in `$ARGUMENTS` if provided; otherwise infer from the current branch name (first integer after the last `/`) or ask the user.
+2. Run: `hexis status read <issue>`
+3. If output shows `STATE: DONE`: proceed.
+4. If output shows any other state: surface the full CLI output verbatim to the user; stop. Do not proceed with commit, push, or PR creation.
+
 ## Process
 
 ### Step 1: Run verify

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -14,6 +14,14 @@ Execute an implementation plan. Default: dispatch subagents per task. Inline exe
 
 If `$ARGUMENTS` is a plan file path, load that file. Otherwise ask the user for the plan file path.
 
+## CLI Integration Gate
+
+After loading the plan and reading the `issue:` value from its frontmatter, before writing any code:
+
+1. Run: `hexis status read <issue>`
+2. If output shows `STATE: IN_PROGRESS`: proceed.
+3. If output shows any other state: surface the full CLI output verbatim to the user; stop. Do not begin implementation.
+
 ## Complexity Check
 
 Before starting, assess task complexity against these criteria (any one is sufficient):

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -14,6 +14,14 @@ Write a detailed implementation plan from a spec. Real code, exact file paths, n
 
 If `$ARGUMENTS` is a file path, read that spec and start. Otherwise ask the user for the spec path.
 
+## CLI Integration Gate
+
+After loading the spec and reading the `issue:` value from its frontmatter, before writing any plan content:
+
+1. Run: `hexis status read <issue>`
+2. If output shows `STATE: NEEDS_PLAN`: proceed.
+3. If output shows any other state: surface the full CLI output verbatim to the user; stop. Do not write any plan content.
+
 ## Scope Check
 
 After loading the spec, check whether the work can be split:

--- a/skills/specify/SKILL.md
+++ b/skills/specify/SKILL.md
@@ -18,6 +18,16 @@ Turn blurry inputs into clear, precise specs. The goal is not to generate ideas 
 
 If `$ARGUMENTS` is provided, treat it as the initial blurry input. Otherwise ask the user what needs to be specified.
 
+## CLI Integration Gate
+
+If an issue number is known from `$ARGUMENTS` or session context (e.g., the current branch is `feat/23-something`):
+
+1. Run: `hexis status read <issue>`
+2. If output shows `STATE: NEEDS_SPEC`: proceed.
+3. If output shows any other state: a spec already exists for this issue. Surface the full CLI output verbatim to the user and ask for explicit confirmation before overwriting. Do not proceed without confirmation.
+
+If no issue number is known (genuinely new work with no GitHub issue yet): skip this gate and proceed.
+
 ## Checklist
 
 - [ ] Identify what is blurry — list specific ambiguities

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -16,6 +16,18 @@ A claim without evidence is a lie.
 
 If `$ARGUMENTS` describes the verification scope, use it. Otherwise infer from current context.
 
+## CLI Integration Gate
+
+### Entry Gate
+
+At skill start, before running any verification commands:
+
+1. Obtain the issue number: use the number in `$ARGUMENTS` if provided; otherwise infer from the current branch name (first integer after the last `/`) or ask the user.
+2. Run: `hexis status read <issue> --json`
+3. If `state` is `NEEDS_VERIFY`: proceed. Surface the `checks` array to the user so they know which items need verification.
+4. If `state` is `IN_PROGRESS`: surface the full CLI output verbatim to the user (blocking plan tasks are shown); stop — implementation must complete first.
+5. If `state` is any other value: surface the full CLI output verbatim to the user; stop.
+
 ## Complexity Check
 
 Before starting, assess scope complexity against these criteria (any one is sufficient):
@@ -79,8 +91,9 @@ Before claiming completion:
 4. VERIFY: does the output confirm the claim?
    - NO: state actual status with evidence
    - YES: proceed to step 5
-5. SYNC: invoke hexis:sync-working-status
-6. ONLY THEN: claim
+5. UPDATE: run `hexis status update <issue> --checked <satisfied-indices> --unchecked <unsatisfied-indices>` using the checks from the entry gate read output (exit gate — updates spec before sync so the change is included in the commit)
+6. SYNC: invoke hexis:sync-working-status
+7. ONLY THEN: claim
 ```
 
 ## On Failure


### PR DESCRIPTION
## Summary
- `dispatch`: replaced grep-based routing with `hexis status read --json`, and expanded routing rules from 8 to 10 (including 5 rules based on `state` labels)
- `specify`, `plan`, `implement`, `finish`: added a `## CLI Integration Gate` section that checks the current state via `hexis status read` when entering the skill and blocks execution if the state does not match
- `verify`: added an entry gate section and inserted an exit gate step (`hexis status update`) into the existing Gate Function before SYNC

## Test Plan
- [ ] Confirm that `dispatch` Step 1b uses `hexis status read N --json` and that five `status.state` routing rules (Rules 2–6) are present
- [ ] Confirm that `specify`, `plan`, `implement`, and `finish` each include a `## CLI Integration Gate` section in the correct location
- [ ] Confirm that the `verify` Gate Function follows the sequence: step 5 UPDATE → step 6 SYNC → step 7 ONLY THEN

Closes #23
